### PR TITLE
Use system default shell (future-proofing for macOS 10.15)

### DIFF
--- a/examples/yabairc
+++ b/examples/yabairc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env sh
 
 # global settings
 yabai -m config mouse_follows_focus          on


### PR DESCRIPTION
Starting with macOS 10.15, [*zsh* will be the default system shell](https://support.apple.com/en-us/HT208050) and *bash* will be deprecated.. This proposed change makes it so that the example configuration uses the system default shell, which is `/bin/bash` on 10.13 and 10.14 and `/bin/zsh` on 10.15. This works because `/bin/sh` is symlinked to the respective shells. 

