### PR TITLE
Add table of contents to docs (visible on GitHub only)

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -3,13 +3,18 @@
 :man manual:   Yabai Manual
 
 ifdef::env-github[]
-:toc:
+:toc: 
+:toc-title:
 :toc-placement!:
-toc::[]
+:numbered:
 endif::[]
 
 yabai(1)
 ========
+
+ifdef::env-github[]
+toc::[]
+endif::[]
 
 Name
 ----

--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -2,6 +2,12 @@
 :man version:  {revnumber}
 :man manual:   Yabai Manual
 
+ifdef::env-github[]
+:toc:
+:toc-placement!:
+toc::[]
+endif::[]
+
 yabai(1)
 ========
 


### PR DESCRIPTION
This change adds an automatically updating table of contents to the asciidoc file in a manner that's only visible on GitHub, so that it does not affect the man page generation at all. Additionally, this change introduces bullet point numbering.

I wasn't sure whether there should be a text like "Table of Contents" above the toc as GitHub does not allow style changes for it, so I made it an empty string for now.

I came across this way to modify asciidocs for viewing on GitHub only [&rightarrow;&nbsp;here](https://gist.github.com/dcode/0cfbf2699a1fe9b46ff04c41721dda74#github-specific-customizations).