### PR TITLE
makefile: clean up output, add linking for building from source

### DIFF
--- a/makefile
+++ b/makefile
@@ -40,8 +40,24 @@ sign:
 	codesign -fs "yabai-cert" $(BUILD_PATH)/yabai
 
 clean:
-	rm -rf $(BUILD_PATH)
+	@if [ -d $(BUILD_PATH) ]; then echo "Removing build path $(BUILD_PATH) ..." && rm -rf $(BUILD_PATH); fi
+	@if [ -L /tmp/yabai_$(USER).lock ]; then echo "Unlinking /tmp/yabai_$(USER).lock ..." && unlink /tmp/yabai_$(USER).lock; fi
+	@if [ -L /tmp/yabai_$(USER).socket ]; then echo "Unlinking /tmp/yabai_$(USER).socket ..." && unlink /tmp/yabai_$(USER).socket; fi
+	@if [ -L /tmp/yabai-sa_$(USER).socket ]; then echo "Unlinking /tmp/yabai-sa_$(USER).socket ..." && unlink /tmp/yabai-sa_$(USER).socket; fi
+	@if [ -L /usr/local/share/man/man1/yabai.1 ]; then echo "Removing man page ..." && unlink /usr/local/share/man/man1/yabai.1; fi
+	@if [ -L /usr/local/bin/yabai ]; then echo "Unlinking binary ..." && unlink /usr/local/bin/yabai; fi
+	@if [ -f ~/.yabairc ]; then echo "Removing configuration file ..." && rm ~/.yabairc; fi
+
 
 $(BUILD_PATH)/yabai: $(YABAI_SRC)
-	mkdir -p $(BUILD_PATH)
+	@echo "Starting build in $(BUILD_PATH) ..."
+	@mkdir -p $(BUILD_PATH)
 	clang $^ $(BUILD_FLAGS) $(FRAMEWORK_PATH) $(FRAMEWORK) -o $@
+	@echo "Creating binary /usr/local/bin/yabai ..."
+	@ln -s ./bin/yabai /usr/local/bin/yabai
+	@echo "Creating man page ..."
+	@ln -s ./doc/yabai.1 /usr/local/share/man/man1/yabai.1
+	@echo "Creating default config file ~/.yabairc ..."
+	@cp ./examples/yabairc ~/.yabairc
+
+

--- a/makefile
+++ b/makefile
@@ -54,10 +54,10 @@ $(BUILD_PATH)/yabai: $(YABAI_SRC)
 	@mkdir -p $(BUILD_PATH)
 	clang $^ $(BUILD_FLAGS) $(FRAMEWORK_PATH) $(FRAMEWORK) -o $@
 	@echo "Creating binary /usr/local/bin/yabai ..."
-	@ln -s ./bin/yabai /usr/local/bin/yabai
+	@ln -s $(PWD)/bin/yabai /usr/local/bin/yabai
 	@echo "Creating man page ..."
-	@ln -s ./doc/yabai.1 /usr/local/share/man/man1/yabai.1
+	@ln -s $(PWD)/doc/yabai.1 /usr/local/share/man/man1/yabai.1
 	@echo "Creating default config file ~/.yabairc ..."
-	@cp ./examples/yabairc ~/.yabairc
+	@cp $(PWD)/examples/yabairc ~/.yabairc
 
 


### PR DESCRIPTION
 ### The purpose of this pull request is to make things easier when building from source/cloning the repo

Added:
 - symlinks for binary and man page included with running `make` or `make install`
 - config file ./examples/yabairc is copied to ~/.yabairc
 - removal of binary, man pages, .lock and .socket symlinks when running `make clean`
 - suppressed command output (didn't suppress clang)
 - messages that indicate what is happening (i.e. "Removing man page...")
 - `make` and `make install` both invoke the `clean` rule first, so I added testing to see if the aforementioned files exist before attempting to remove them

(if these changes are added, the readme would also have to be updated for building from source. I didn't add that here but could help w that if needed)

I considered adding variables to the makefile for a few things, so if it's requested that those are added I can do so. Any other feedback/suggestions for this are appreciated.