### PR TITLE
Add status_bar_power_icon_strip_color and status_bar_underline_color

### DIFF
--- a/src/bar.c
+++ b/src/bar.c
@@ -294,11 +294,21 @@ void bar_set_background_color(struct bar *bar, uint32_t color)
     bar_refresh(bar);
 }
 
+void bar_set_underline_color(struct bar *bar, uint32_t color)
+{
+    bar->space_underline = bar_prepare_line(bar->t_font, "______", rgba_color_from_hex(color));
+    bar->power_underline = bar_prepare_line(bar->t_font, "__________", rgba_color_from_hex(color));
+    bar->clock_underline = bar_prepare_line(bar->t_font, "__________", rgba_color_from_hex(color));
+    bar_refresh(bar);
+}
+
 void bar_set_text_font(struct bar *bar, char *font_string)
 {
     if (bar->t_font) {
         CFRelease(bar->t_font);
     }
+
+    uint32_t color = bar->space_underline.color.p;
 
     if (bar->space_underline.line) {
         bar_destroy_line(bar->space_underline);
@@ -321,9 +331,9 @@ void bar_set_text_font(struct bar *bar, char *font_string)
     }
 
     bar->t_font = bar_create_font(bar->t_font_prop);
-    bar->space_underline = bar_prepare_line(bar->t_font, "______", rgba_color_from_hex(0xffd4d232));
-    bar->power_underline = bar_prepare_line(bar->t_font, "__________", rgba_color_from_hex(0xffd75f5f));
-    bar->clock_underline = bar_prepare_line(bar->t_font, "__________", rgba_color_from_hex(0xff458588));
+    bar->space_underline = bar_prepare_line(bar->t_font, "______", rgba_color_from_hex(color));
+    bar->power_underline = bar_prepare_line(bar->t_font, "__________", rgba_color_from_hex(color));
+    bar->clock_underline = bar_prepare_line(bar->t_font, "__________", rgba_color_from_hex(color));
     bar_refresh(bar);
 }
 
@@ -400,6 +410,20 @@ void bar_set_power_strip(struct bar *bar, char **icon_strip)
     } else {
         bar->battr_icon = bar_prepare_line(bar->i_font, "", rgba_color_from_hex(0xffd75f5f));
         bar->power_icon = bar_prepare_line(bar->i_font, "", rgba_color_from_hex(0xffcd950c));
+    }
+
+    bar_refresh(bar);
+}
+
+
+void bar_set_power_strip_color(struct bar *bar, uint32_t color)
+{
+    if (buf_len(bar->_power_icon_strip) == 2) {
+        bar->battr_icon = bar_prepare_line(bar->i_font, bar->_power_icon_strip[0], rgba_color_from_hex(color));
+        bar->power_icon = bar_prepare_line(bar->i_font, bar->_power_icon_strip[1], rgba_color_from_hex(color));
+    } else {
+        bar->battr_icon = bar_prepare_line(bar->i_font, "", rgba_color_from_hex(color));
+        bar->power_icon = bar_prepare_line(bar->i_font, "", rgba_color_from_hex(color));
     }
 
     bar_refresh(bar);

--- a/src/bar.h
+++ b/src/bar.h
@@ -55,10 +55,12 @@ struct bar
 
 void bar_set_foreground_color(struct bar *bar, uint32_t color);
 void bar_set_background_color(struct bar *bar, uint32_t color);
+void bar_set_underline_color(struct bar *bar, uint32_t color);
 void bar_set_text_font(struct bar *bar, char *font_string);
 void bar_set_icon_font(struct bar *bar, char *font_string);
 void bar_set_space_strip(struct bar *bar, char **icon_strip);
 void bar_set_power_strip(struct bar *bar, char **icon_strip);
+void bar_set_power_strip_color(struct bar *bar, uint32_t color);
 void bar_set_clock_icon(struct bar *bar, char *icon);
 void bar_set_space_icon(struct bar *bar, char *icon);
 

--- a/src/message.c
+++ b/src/message.c
@@ -46,8 +46,10 @@ extern struct bar g_bar;
 #define COMMAND_CONFIG_BAR_ICON_FONT         "status_bar_icon_font"
 #define COMMAND_CONFIG_BAR_BACKGROUND        "status_bar_background_color"
 #define COMMAND_CONFIG_BAR_FOREGROUND        "status_bar_foreground_color"
+#define COMMAND_CONFIG_BAR_UNDERLINE         "status_bar_underline_color"
 #define COMMAND_CONFIG_BAR_SPACE_STRIP       "status_bar_space_icon_strip"
 #define COMMAND_CONFIG_BAR_POWER_STRIP       "status_bar_power_icon_strip"
+#define COMMAND_CONFIG_BAR_POWER_STRIP_COLOR "status_bar_power_icon_strip_color"
 #define COMMAND_CONFIG_BAR_SPACE_ICON        "status_bar_space_icon"
 #define COMMAND_CONFIG_BAR_CLOCK_ICON        "status_bar_clock_icon"
 
@@ -716,6 +718,20 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
                 daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
             }
         }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_UNDERLINE)) {
+        struct token value = get_token(&message);
+        if (!token_is_valid(value)) {
+            fprintf(rsp, "0x%x\n", g_bar.space_underline.color.p);
+            fprintf(rsp, "0x%x\n", g_bar.power_underline.color.p);
+            fprintf(rsp, "0x%x\n", g_bar.clock_underline.color.p);
+        } else {
+            uint32_t color = token_to_uint32t(value);
+            if (color) {
+                bar_set_underline_color(&g_bar, color);
+            } else {
+                daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+            }
+        }
     } else if (token_equals(command, COMMAND_CONFIG_BAR_SPACE_STRIP)) {
         char **icon_strip = NULL;
         struct token token = get_token(&message);
@@ -734,6 +750,19 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
         bar_set_power_strip(&g_bar, icon_strip);
         if (buf_len(g_bar._power_icon_strip) != 2) {
             daemon_fail(rsp, "value for '%.*s' must contain exactly two symbols separated by whitespace.\n", command.length, command.text);
+        }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_POWER_STRIP_COLOR)) {
+        struct token value = get_token(&message);
+        if (!token_is_valid(value)) {
+            fprintf(rsp, "0x%x\n", g_bar.power_icon.color.p);
+            fprintf(rsp, "0x%x\n", g_bar.battr_icon.color.p);
+        } else {
+            uint32_t color = token_to_uint32t(value);
+            if (color) {
+                bar_set_power_strip_color(&g_bar, color);
+            } else {
+                daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+            }
         }
     } else if (token_equals(command, COMMAND_CONFIG_BAR_SPACE_ICON)) {
         struct token token = get_token(&message);


### PR DESCRIPTION
I wanted to be able to configure the icon colours for the power strip and the underlines in the bar and I came up with this.

I have never really written any C code, but I tried to stick to the style of the codebase as best as I could. I'm not sure if there is even any interest in integrating something like this into the codebase, but I have used your tools for many years now and this is my little way of trying to give something back for the weeks and months of increased productivity since I first found `kwm`.

```
yabai -m config status_bar_underline_color          0xFF3777E6
yabai -m config status_bar_power_icon_strip_color   0xFF3777E6
```

This implementation doesn't distinguish between setting different colours for the battery and power icons, and it doesn't distinguish between setting different underline colours for the spaces, power and clock strips.