### PR TITLE
Fix inconsistent tense in documentation

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -46,10 +46,10 @@ Options
     Use the specified configuration file.
 
 *--install-sa*::
-    Install scripting-addition. Must be ran as root. Path is /System/Library/ScriptingAdditions on macOS High Sierra, and /Library/ScriptingAdditions on Mojave and newer.
+    Install scripting-addition. Must be run as root. Path is /System/Library/ScriptingAdditions on macOS High Sierra, and /Library/ScriptingAdditions on Mojave and newer.
 
 *--uninstall-sa*::
-    Uninstall scripting-addition. Must be ran as root. Path is /System/Library/ScriptingAdditions on macOS High Sierra, and /Library/ScriptingAdditions on Mojave and newer.
+    Uninstall scripting-addition. Must be run as root. Path is /System/Library/ScriptingAdditions on macOS High Sierra, and /Library/ScriptingAdditions on Mojave and newer.
 
 *--check-sa*::
     Returns a zero exit-code if the latest version of the scripting-addition is installed.


### PR DESCRIPTION
The problem was that the first part of the sentence "must be run" is future tense, but the next word was past tense. I have edited this so that tense is consistent in both places.