### PR TITLE
"Almost" fix status_bar placement

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -102,6 +102,9 @@ Colors are in the form '#AARRGGBB'.
 'status_bar'::
     Enable custom status bar.
 
+'status_bar_position'::
+    Specify the position on the screen of the status bar. Accept the following values: *top*, *bottom*.
+
 'status_bar_text_font'::
     Specify name, style and size of font to use for drawing text. Format: '<font_family>:<font_style>:<font_size>'. Use 'Font Book.app' to identify the correct name.
 

--- a/src/bar.c
+++ b/src/bar.c
@@ -270,11 +270,23 @@ void bar_resize(struct bar *bar)
     CGSNewRegionWithRect(&bar->frame, &frame_region);
     SLSDisableUpdate(g_connection);
     SLSOrderWindow(g_connection, bar->id, -1, 0);
-    SLSSetWindowShape(g_connection, bar->id, 0.0f, 0.0f, frame_region);
+
+    if (bar->position == Top) {
+      SLSSetWindowShape(g_connection, bar->id, 0.0f, 0.0f, frame_region);
+    } else {
+      SLSSetWindowShape(g_connection, bar->id, 0.0f, bounds.size.height - 26.0f, frame_region);
+    }
+
     bar_refresh(bar);
     SLSOrderWindow(g_connection, bar->id, 1, 0);
     SLSReenableUpdate(g_connection);
     CFRelease(frame_region);
+}
+
+void bar_set_position(struct bar *bar, enum bar_position position)
+{
+    bar->position = position;
+    bar_refresh(bar);
 }
 
 void bar_set_foreground_color(struct bar *bar, uint32_t color)
@@ -447,6 +459,7 @@ void bar_create(struct bar *bar)
 {
     if (bar->enabled) return;
 
+    if (!bar->position)    bar_set_position(bar, Top);
     if (!bar->t_font_prop) bar_set_text_font(bar, string_copy("Helvetica Neue:Regular:10.0"));
     if (!bar->i_font_prop) bar_set_icon_font(bar, string_copy("FontAwesome:Regular:10.0"));
     if (!bar->background_color.is_valid) bar_set_background_color(bar, 0xff202020);
@@ -473,7 +486,13 @@ void bar_create(struct bar *bar)
     bar->frame = (CGRect) {{0,0},{bounds.size.width, 26}};
 
     CGSNewRegionWithRect(&bar->frame, &frame_region);
-    SLSNewWindow(g_connection, 2, 0.0f, 0.0f, frame_region, &bar->id);
+
+    if (bar->position == Top) {
+      SLSNewWindow(g_connection, 2, 0.0f, 0.0f, frame_region, &bar->id);
+    } else {
+      SLSNewWindow(g_connection, 2, 0.0f, bounds.size.height - 26.0f, frame_region, &bar->id);
+    }
+
     CFRelease(frame_region);
 
     SLSSetWindowResolution(g_connection, bar->id, 2.0f);

--- a/src/bar.h
+++ b/src/bar.h
@@ -23,9 +23,15 @@ struct bar_line
     struct rgba_color color;
 };
 
+enum bar_position {
+    Top = 0,
+    Bottom = 1
+};
+
 struct bar
 {
     bool enabled;
+    enum bar_position position;
     uint32_t id;
     uint32_t did;
     CGContextRef context;
@@ -53,6 +59,7 @@ struct bar
     struct bar_line clock_underline;
 };
 
+void bar_set_position(struct bar *bar, enum bar_position position);
 void bar_set_foreground_color(struct bar *bar, uint32_t color);
 void bar_set_background_color(struct bar *bar, uint32_t color);
 void bar_set_text_font(struct bar *bar, char *font_string);

--- a/src/display.c
+++ b/src/display.c
@@ -84,7 +84,9 @@ CGRect display_bounds_constrained(uint32_t did)
     CGRect dock   = display_manager_dock_rect();
 
     if (g_bar.enabled && did == display_manager_main_display_id()) {
-        frame.origin.y    += g_bar.frame.size.height;
+        if (g_bar.position == Top) {
+          frame.origin.y    += g_bar.frame.size.height;
+        }
         frame.size.height -= g_bar.frame.size.height;
     }
 

--- a/src/message.c
+++ b/src/message.c
@@ -46,6 +46,7 @@ extern struct bar g_bar;
 #define COMMAND_CONFIG_MOUSE_ACTION1         "mouse_action1"
 #define COMMAND_CONFIG_MOUSE_ACTION2         "mouse_action2"
 #define COMMAND_CONFIG_BAR                   "status_bar"
+#define COMMAND_CONFIG_BAR_POSITION          "status_bar_position"
 #define COMMAND_CONFIG_BAR_TEXT_FONT         "status_bar_text_font"
 #define COMMAND_CONFIG_BAR_ICON_FONT         "status_bar_icon_font"
 #define COMMAND_CONFIG_BAR_BACKGROUND        "status_bar_background_color"
@@ -733,6 +734,12 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
         } else {
             daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
         }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_POSITION)) {
+      if (strcmp(message, "bottom") == 0) {
+          bar_set_position(&g_bar, Bottom);
+      } else {
+          bar_set_position(&g_bar, Top);
+      }
     } else if (token_equals(command, COMMAND_CONFIG_BAR_TEXT_FONT)) {
         int length = strlen(message);
         if (length <= 0) {


### PR DESCRIPTION
Fixes #220 (well, almost!) .

@koekeishiya This follows up my enquiry on issue #220. This PR should be sufficient to add a new `status_bar_position` setting which accepts `top` and `bottom` as two potential values (it defaults to `top` even in case of an invalid value). It does its job and as a matter of fact I am now using this fork to have the status bar displayed at the bottom. I say it "almost" work because there is one caveat: you have to specify the position (in the config file) to be *before* the `on/off` command, like so:

```
#!/usr/bin/env sh

# bar settings
yabai -m config status_bar_position          bottom
yabai -m config status_bar                   on
```

You can imagine why: the `message.c` is build (from my understanding) as a loop which process each command line-by-line, and the actual drawing of the bar happens when we encounter the `status_bar` command, and we cannot retroactively change the position later (or, at least, I don't know how to do that 😉 ).

This is obviously not great, so I am all ears if you have ideas on how to lift this restriction.

Thanks again for your work!
