### PR TITLE
Add codesign wrapper script

### DIFF
--- a/scripts/codesign
+++ b/scripts/codesign
@@ -4,6 +4,17 @@ identities="$(security find-identity -v -p codesigning | sed '$d')"
 id_count="$(echo "${identities}" | wc -l)"
 target="$(command -v "${1:-}")"
 
+function error() {
+	{
+		echo "$(tput bold)Error: ${@}$(tput sgr0)"
+		echo
+		echo "Usage: ./scripts/codesign <path/to/executable> [<certificate>]"
+		echo "Available codesigning certificates:"
+		echo "${identities}"
+	} >&2
+	exit 1
+}
+
 if [ "${id_count}" -lt 1 ]; then
 	>&2 echo "Unable to find a codesigning identity"
 	exit 1
@@ -12,17 +23,23 @@ elif [ "${id_count}" -eq 1 ]; then
 elif [ "${id_count}" -gt 1 ] && [ "${#}" -eq 2 ]; then
 	selection="${2}"
 elif [ -x "${target}" ]; then
-	{
-		echo "Usage: ./scripts/codesign <path/to/bin> <certificate index>"
-		echo "Found multiple codesigning certificates. Please select:"
-		echo "${identities}"
-	} >&2
-	exit 2
+	error "Unable to auto-select codesigning certificate"
 else
-	>&2 echo "Usage: ./scripts/codesign <path/to/bin> [<certificate index>]"
-	exit 1
+	error "Unable to find executable \"${target}\""
 fi
 
-certificate="$(echo "${identities}" | awk "NR==${selection} {print \$2}")"
+if [ -z "${selection##[0-9]*}" ]; then
+	certificate="$(echo "${identities}" \
+		| awk "NR==${selection} {print \$2}")"
+else
+	certificate="$(echo "${identities}" \
+		| awk 'BEGIN{FS=OFS="\""} {gsub(/ /,"\\ ",$2)} 1' \
+		| awk "\$3==\"\\\"${selection// /_}\\\"\" {print \$2}")"
+fi
+
+if [ -z "${certificate}" ]; then
+	error "Unable to find codesigning certificate \"${selection}\""
+fi
+
 command codesign --deep --force --verbose --sign "${certificate}" "${target}"
 

--- a/scripts/codesign
+++ b/scripts/codesign
@@ -28,17 +28,19 @@ else
 	error "Unable to find executable \"${target}\""
 fi
 
-if [ -z "${selection##[0-9]*}" ]; then
+if [[ "${selection}" =~ ^[0-9]+$ ]]; then
 	certificate="$(echo "${identities}" \
 		| awk "NR==${selection} {print \$2}")"
 else
 	certificate="$(echo "${identities}" \
-		| awk 'BEGIN{FS=OFS="\""} {gsub(/ /,"\\ ",$2)} 1' \
-		| awk "\$3==\"\\\"${selection// /_}\\\"\" {print \$2}")"
+		| awk 'BEGIN{FS=OFS="\""} {gsub(/ /,"_",$2)} 1' \
+		| awk "\$3 ~ /${selection// /_}/ {print \$2}")"
 fi
 
 if [ -z "${certificate}" ]; then
 	error "Unable to find codesigning certificate \"${selection}\""
+elif [ "$(echo "${certificate}" | wc -l)" -ne 1 ]; then
+	error "Unable to uniquely identify codesigning certificate \"${selection}\""
 fi
 
 command codesign --deep --force --verbose --sign "${certificate}" "${target}"

--- a/scripts/codesign
+++ b/scripts/codesign
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+identities="$(security find-identity -v -p codesigning | sed '$d')"
+id_count="$(echo "${identities}" | wc -l)"
+target="$(command -v "${1:-}")"
+
+if [ "${id_count}" -lt 1 ]; then
+	>&2 echo "Unable to find a codesigning identity"
+	exit 1
+elif [ "${id_count}" -eq 1 ]; then
+	selection="1"
+elif [ "${id_count}" -gt 1 ] && [ "${#}" -eq 2 ]; then
+	selection="${2}"
+elif [ -x "${target}" ]; then
+	{
+		echo "Usage: ./scripts/codesign <path/to/bin> <certificate index>"
+		echo "Found multiple codesigning certificates. Please select:"
+		echo "${identities}"
+	} >&2
+	exit 2
+else
+	>&2 echo "Usage: ./scripts/codesign <path/to/bin> [<certificate index>]"
+	exit 1
+fi
+
+certificate="$(echo "${identities}" | awk "NR==${selection} {print \$2}")"
+command codesign --deep --force --verbose --sign "${certificate}" "${target}"
+


### PR DESCRIPTION
The newly added `scripts/codesign` is a convenience wrapper around codesign for easier and proper codesigning of Mach-O thin executables like yabai. It expects two arguments: a path to the binary (e.g., `yabai`) and, if multiple codesigning identities are available, the index of the listed codesigning identities.

Proper use of `codesign` is hard, and this script should alleviate some of the trouble users have been having, especially with regards to the changes in recent versions of macOS.