### PR TITLE
Fix kitty application path

### DIFF
--- a/examples/skhdrc
+++ b/examples/skhdrc
@@ -1,5 +1,5 @@
 # open terminal
-cmd - return : /Applications/Kitty.app/Contents/MacOS/kitty --single-instance -d ~
+cmd - return : /Applications/kitty.app/Contents/MacOS/kitty --single-instance -d ~
 
 # focus window
 alt - h : yabai -m window --focus west


### PR DESCRIPTION
Just a minor capitalization fix for the [kitty](https://sw.kovidgoyal.net/kitty/) application path in the default config: kitty gets installed into `/Applications/kitty.app` (not `/Applications/Kitty.app`) - On a non case-insensitive partition this would break the launcher (it just wouldn't do anything).