### PR TITLE
Feature.coordinate display selectors

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -82,7 +82,7 @@ DIR_SEL     := north | east | south | west
 
 WINDOW_SEL  := prev | next | first | last | recent | mouse | largest | smallest | DIR_SEL | <window id>
 
-DISPLAY_SEL := prev | next | first | last | recent | <arrangement index (1-based)>
+DISPLAY_SEL := prev | next | first | last | recent | <arrangement index (1-based)> | x:<index from left to right> | y:<index from top to bottom>
 
 SPACE_SEL   := prev | next | first | last | recent | <mission-control index (1-based)> | LABEL
 

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -91,11 +91,12 @@ CFStringRef display_manager_arrangement_display_uuid(int arrangement)
     CFStringRef result = NULL;
     CFArrayRef displays = SLSCopyManagedDisplays(g_connection);
 
+    // 1-index
+    arrangement--;
+
     int displays_count = CFArrayGetCount(displays);
-    for (int i = 0; i < displays_count; ++i) {
-        if ((i+1) != arrangement) continue;
-        result = CFRetain(CFArrayGetValueAtIndex(displays, i));
-        break;
+    if (arrangement >= 0 && arrangement < displays_count) {
+        result = CFRetain(CFArrayGetValueAtIndex(displays, arrangement));
     }
 
     CFRelease(displays);
@@ -108,12 +109,14 @@ uint32_t display_manager_arrangement_display_id(int arrangement)
     CFArrayRef displays = SLSCopyManagedDisplays(g_connection);
 
     int displays_count = CFArrayGetCount(displays);
-    for (int i = 0; i < displays_count; ++i) {
-        if ((i+1) != arrangement) continue;
-        CFUUIDRef uuid_ref = CFUUIDCreateFromString(NULL, CFArrayGetValueAtIndex(displays, i));
+
+    // 1-index
+    arrangement--;
+
+    if (arrangement >= 0 && arrangement < displays_count) {
+        CFUUIDRef uuid_ref = CFUUIDCreateFromString(NULL, CFArrayGetValueAtIndex(displays, arrangement));
         result = CGDisplayGetDisplayIDFromUUID(uuid_ref);
         CFRelease(uuid_ref);
-        break;
     }
 
     CFRelease(displays);

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -1,4 +1,5 @@
 #include "display_manager.h"
+#include <assert.h>
 
 extern struct display_manager g_display_manager;
 extern struct window_manager g_window_manager;
@@ -116,6 +117,51 @@ uint32_t display_manager_arrangement_display_id(int arrangement)
     }
 
     CFRelease(displays);
+    return result;
+}
+
+static inline int display_frame_center(CFStringRef uuid_str, char axis) {
+    CFUUIDRef uuid_ref = CFUUIDCreateFromString(NULL, uuid_str);
+    uint32_t did = CGDisplayGetDisplayIDFromUUID(uuid_ref);
+    CGRect frame = CGDisplayBounds(did);
+    if (axis == 'x') return frame.origin.x + (frame.size.width) / 2;
+    if (axis == 'y') return frame.origin.y + (frame.size.height) / 2;
+
+    // axis should only have these two values
+    assert(false);
+}
+
+static enum CFComparisonResult coordinate_comparator(const void *a_p, const void *b_p, void *context_p) {
+    CFStringRef a = (CFStringRef) a_p;
+    CFStringRef b = (CFStringRef) b_p;
+    char axis = *((char *) context_p);
+
+    int center_a = display_frame_center(a, axis);
+    int center_b = display_frame_center(b, axis);
+
+    if (center_a < center_b) return kCFCompareLessThan;
+    if (center_a > center_b) return kCFCompareGreaterThan;
+    return kCFCompareEqualTo;
+}
+
+
+uint32_t display_manager_coordinate_display_id(char axis, int index) {
+    uint32_t result = 0;
+    CFArrayRef displays = SLSCopyManagedDisplays(g_connection);
+    int displays_count = CFArrayGetCount(displays);
+
+    index--; // 1-indexed -> 0-indexed
+
+    if (index >= 0 && index < displays_count) {
+        // copy the array to a mutable one, then sort it in place
+        CFRange all = CFRangeMake((long) 0, (long) displays_count - 1);
+        CFMutableArrayRef mut_displays = CFArrayCreateMutableCopy(NULL, displays_count, displays);
+        CFArraySortValues(mut_displays, all, &coordinate_comparator, &axis);
+
+        CFUUIDRef uuid_ref = CFUUIDCreateFromString(NULL, CFArrayGetValueAtIndex(mut_displays, index));
+        result = CGDisplayGetDisplayIDFromUUID(uuid_ref);
+    }
+
     return result;
 }
 

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -128,7 +128,7 @@ static inline int display_frame_center(CFStringRef uuid_str, char axis) {
     if (axis == 'y') return frame.origin.y + (frame.size.height) / 2;
 
     // axis should only have these two values
-    assert(false);
+    return 0;
 }
 
 static enum CFComparisonResult coordinate_comparator(const void *a_p, const void *b_p, void *context_p) {

--- a/src/display_manager.h
+++ b/src/display_manager.h
@@ -48,6 +48,7 @@ uint32_t display_manager_dock_display_id(void);
 CFStringRef display_manager_cursor_display_uuid(void);
 uint32_t display_manager_cursor_display_id(void);
 CFStringRef display_manager_arrangement_display_uuid(int arrangement);
+uint32_t display_manager_coordinate_display_id(char axis, int index);
 uint32_t display_manager_arrangement_display_id(int arrangement);
 uint32_t display_manager_prev_display_id(uint32_t did);
 uint32_t display_manager_next_display_id(uint32_t did);


### PR DESCRIPTION
Implements #550 .

Adds `x:<number>` and `y:<number>` as valid display selectors, which will indicate a display based on its horizontal or vertical position.

For now the numbers must be positive.