### PR TITLE
implement display_sort_order config option

### DIFF
--- a/doc/yabai.1
+++ b/doc/yabai.1
@@ -154,6 +154,17 @@ When focusing a window, put the mouse at its center.
 Automatically focus the window under the mouse.
 .RE
 .sp
+\fBdisplay_sort_order\fP [\fIhorizontal|vertical|none\fP]
+.RS 4
+Specify how displays are ordered.
+.br
+\fIhorizontal\fP|\fIvertical\fP: order by the display\(cqs relative position.
+.br
+\fInone\fP: (default) use the native ordering.
+.br
+The position of a display is determined by its center point.
+.RE
+.sp
 \fBwindow_placement\fP [\fIfirst_child|second_child\fP]
 .RS 4
 Specify whether managed windows should become the first or second leaf\-node.

--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -122,6 +122,12 @@ Global Settings
 *focus_follows_mouse* ['autofocus|autoraise|off']::
     Automatically focus the window under the mouse.
 
+*display_sort_order* ['horizontal|vertical|none']::
+    Specify how displays are ordered. +
+    'horizontal'|'vertical': order by the display's relative position. +
+    'none': (default) use the native ordering. +
+    The position of a display is determined by its center point.
+
 *window_placement* ['first_child|second_child']::
     Specify whether managed windows should become the first or second leaf-node.
 

--- a/src/display.c
+++ b/src/display.c
@@ -127,6 +127,21 @@ CGRect display_bounds_constrained(uint32_t did)
     return frame;
 }
 
+static inline float display_frame_center(enum display_sort_order axis, CFStringRef uuid_str) {
+    CFUUIDRef uuid_ref = CFUUIDCreateFromString(NULL, uuid_str);
+    uint32_t did = CGDisplayGetDisplayIDFromUUID(uuid_ref);
+    CGRect frame = CGDisplayBounds(did);
+
+    switch(axis) {
+      case DISPLAY_SORT_HORIZ: return frame.origin.x + (frame.size.width) / 2;
+      case DISPLAY_SORT_VERT: return frame.origin.y + (frame.size.height) / 2;
+
+      // should not get here, but if we do it'll just result in not sorting
+      // (considering every display to be "equal")
+      default: return 0.0;
+    }
+}
+
 CGPoint display_center(uint32_t did)
 {
     CGRect bounds = display_bounds(did);

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -107,8 +107,8 @@ static enum CFComparisonResult coordinate_comparator(const void *a_p, const void
     uint32_t did_a = CGDisplayGetDisplayIDFromUUID(uuid_a);
     uint32_t did_b = CGDisplayGetDisplayIDFromUUID(uuid_b);
 
-    CFRelease(uuid_a);
-    CFRelease(uuid_b);
+    // if (uuid_a) CFRelease(uuid_a);
+    // if (uuid_b) CFRelease(uuid_b);
 
     CGPoint center_a = display_center(did_a);
     CGPoint center_b = display_center(did_b);

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -146,7 +146,7 @@ CFStringRef display_manager_arrangement_display_uuid(int arrangement)
             // copy the array to a mutable one, then sort it in place
             CFRange all = CFRangeMake((long) 0, (long) count);
             CFMutableArrayRef mut_displays = CFArrayCreateMutableCopy(NULL, count, displays);
-            CFArraySortValues(mut_displays, all, &coordinate_comparator, NULL);
+            CFArraySortValues(mut_displays, all, &coordinate_comparator, &g_display_manager.sort_order);
             result = CFRetain(CFArrayGetValueAtIndex(mut_displays, index));
             CFRelease(mut_displays);
         }

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -107,6 +107,9 @@ static enum CFComparisonResult coordinate_comparator(const void *a_p, const void
     uint32_t did_a = CGDisplayGetDisplayIDFromUUID(uuid_a);
     uint32_t did_b = CGDisplayGetDisplayIDFromUUID(uuid_b);
 
+    CFRelease(uuid_a);
+    CFRelease(uuid_b);
+
     CGPoint center_a = display_center(did_a);
     CGPoint center_b = display_center(did_b);
 

--- a/src/display_manager.h
+++ b/src/display_manager.h
@@ -5,6 +5,20 @@
 #define DOCK_ORIENTATION_LEFT   3
 #define DOCK_ORIENTATION_RIGHT  4
 
+enum display_sort_order
+{
+  DISPLAY_SORT_NONE,
+  DISPLAY_SORT_HORIZ,
+  DISPLAY_SORT_VERT
+};
+
+static const char *display_sort_order_str[] =
+{
+  "none",
+  "horizontal",
+  "vertical"
+};
+
 enum external_bar_mode
 {
     EXTERNAL_BAR_OFF,
@@ -23,6 +37,8 @@ struct display_manager
 {
     uint32_t current_display_id;
     uint32_t last_display_id;
+
+    enum display_sort_order sort_order;
 
     int top_padding;
     int bottom_padding;

--- a/src/message.c
+++ b/src/message.c
@@ -21,6 +21,7 @@ extern bool g_verbose;
 #define COMMAND_CONFIG_MFF                   "mouse_follows_focus"
 #define COMMAND_CONFIG_FFM                   "focus_follows_mouse"
 #define COMMAND_CONFIG_WINDOW_PLACEMENT      "window_placement"
+#define COMMAND_CONFIG_DISPLAY_SORT          "display_sort_order"
 #define COMMAND_CONFIG_TOPMOST               "window_topmost"
 #define COMMAND_CONFIG_OPACITY               "window_opacity"
 #define COMMAND_CONFIG_OPACITY_DURATION      "window_opacity_duration"
@@ -50,6 +51,9 @@ extern bool g_verbose;
 
 #define ARGUMENT_CONFIG_FFM_AUTOFOCUS        "autofocus"
 #define ARGUMENT_CONFIG_FFM_AUTORAISE        "autoraise"
+#define ARGUMENT_CONFIG_DISPLAY_SORT_NONE    "none"
+#define ARGUMENT_CONFIG_DISPLAY_SORT_HORIZ   "horizontal"
+#define ARGUMENT_CONFIG_DISPLAY_SORT_VERT    "vertical"
 #define ARGUMENT_CONFIG_WINDOW_PLACEMENT_FST "first_child"
 #define ARGUMENT_CONFIG_WINDOW_PLACEMENT_SND "second_child"
 #define ARGUMENT_CONFIG_SHADOW_FLT           "float"

--- a/src/message.c
+++ b/src/message.c
@@ -999,6 +999,19 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
         } else {
             daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
         }
+    } else if (token_equals(command, COMMAND_CONFIG_DISPLAY_SORT)) {
+        struct token value = get_token(&message);
+        if (!token_is_valid(value)) {
+            fprintf(rsp, "%s\n", window_node_child_str[g_space_manager.window_placement]);
+        } else if (token_equals(value, ARGUMENT_CONFIG_DISPLAY_SORT_NONE)) {
+            g_display_manager.sort_order = DISPLAY_SORT_NONE;
+        } else if (token_equals(value, ARGUMENT_CONFIG_DISPLAY_SORT_HORIZ)) {
+            g_display_manager.sort_order = DISPLAY_SORT_HORIZ;
+        } else if (token_equals(value, ARGUMENT_CONFIG_DISPLAY_SORT_VERT)) {
+            g_display_manager.sort_order = DISPLAY_SORT_VERT;
+        } else {
+            daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+        }
     } else if (token_equals(command, COMMAND_CONFIG_TOPMOST)) {
         struct token value = get_token(&message);
         if (!token_is_valid(value)) {


### PR DESCRIPTION
Alternate proposal to #551 .

Usage: `yabai -m config display_sort_order [none|horizontal|vertical] (default: none)`

If set to something other than `none`, display arrangement indexes will be considered relative to their position, either sorted horizontally or vertically. This also affects the behaviour of the positional selectors `next`, `prev`, `first`, and `last`, making it ideal for #225 .