### PR TITLE
Add more options for mouse actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 _This is a fork of koekeishiya's yabai tiling window manager; its main differences are allowing moving windows without scripting addition (use the mouse action `move2`), and using multiple modifier keys for mouse actions. It also supports more than 2 mouse actions._
 
-_This package is head-only; to install, do `brew install sourtin/formulae/yabai-sourtin` and then `brew services start yabai-sourtin`._
+_This package is head-only; to install, do `brew install --HEAD sourtin/formulae/yabai-sourtin` and then `brew services start yabai-sourtin`._
 
 <!-- Please be careful editing the below HTML, as GitHub is quite finicky with anything that looks like an HTML tag in GitHub Flavored Markdown. -->
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+_This is a fork of koekeishiya's yabai tiling window manager; its main differences are allowing moving windows without scripting addition (use the mouse action `move2`), and using multiple modifier keys for mouse actions (use `+` as a delimiter, e.g. `cmd+ctrl`, or `super` as a shortcut for `cmd+ctrl+shift+alt`)._
+
+_This package is head-only; to install, do `brew install sourtin/formulae/yabai-sourtin` and then `brew services start yabai-sourtin`._
+
 <!-- Please be careful editing the below HTML, as GitHub is quite finicky with anything that looks like an HTML tag in GitHub Flavored Markdown. -->
 <p align="center">
   <img width="75%" src="assets/banner/banner.svg" alt="Banner">

--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -163,8 +163,9 @@ Global Settings
 *auto_balance* ['<BOOL_SEL>']::
     Balance the window tree upon change, so that all windows occupy the same area.
 
-*mouse_modifier* ['cmd|alt|shift|ctrl|fn']::
-    Keyboard modifier used for moving and resizing windows.
+*mouse_modifier* ['cmd|alt|shift|ctrl|fn|super']::
+    Keyboard modifier used for moving and resizing windows. +
+    Additional modifiers can be specified by separating them with '+', for example 'cmd+alt+fn'. A shorthand for 'cmd+alt+shift+ctrl' is provided via 'super'.
 
 *mouse_action1* ['move|move2|resize']::
     Action performed when pressing 'mouse_modifier' + 'button1'. +

--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -166,11 +166,13 @@ Global Settings
 *mouse_modifier* ['cmd|alt|shift|ctrl|fn']::
     Keyboard modifier used for moving and resizing windows.
 
-*mouse_action1* ['move|resize']::
-    Action performed when pressing 'mouse_modifier' + 'button1'.
+*mouse_action1* ['move|move2|resize']::
+    Action performed when pressing 'mouse_modifier' + 'button1'. +
+    If the scripting-addition is not installed, move will not work. In this case, move2 may be used although it is less performant.
 
-*mouse_action2* ['move|resize']::
-    Action performed when pressing 'mouse_modifier' + 'button2'.
+*mouse_action2* ['move|move2|resize']::
+    Action performed when pressing 'mouse_modifier' + 'button2'. +
+    If the scripting-addition is not installed, move will not work. In this case, move2 may be used although it is less performant.
 
 Space Settings
 ^^^^^^^^^^^^^^

--- a/src/event.c
+++ b/src/event.c
@@ -832,6 +832,13 @@ static EVENT_CALLBACK(EVENT_HANDLER_MOUSE_DRAGGED)
         int dx = point.x - g_mouse_state.down_location.x;
         int dy = point.y - g_mouse_state.down_location.y;
         window_manager_move_window_cgs(g_mouse_state.window, g_mouse_state.window_frame.origin.x, g_mouse_state.window_frame.origin.y, dx, dy);
+    } else if (g_mouse_state.current_action == MOUSE_MODE_MOVE_LEGACY) {
+        CGPoint point = CGEventGetLocation(context);
+        int dx = point.x - g_mouse_state.down_location.x;
+        int dy = point.y - g_mouse_state.down_location.y;
+        float fx = g_mouse_state.window_frame.origin.x + dx;
+        float fy = g_mouse_state.window_frame.origin.y + dy;
+        window_manager_move_window(g_mouse_state.window, fx, fy);
     } else if (g_mouse_state.current_action == MOUSE_MODE_RESIZE) {
         uint64_t event_time = CGEventGetTimestamp(context);
         float dt = ((float) event_time - g_mouse_state.last_moved_time) * (1.0f / 1E6);

--- a/src/message.c
+++ b/src/message.c
@@ -59,6 +59,7 @@ extern bool g_verbose;
 #define ARGUMENT_CONFIG_MOUSE_MOD_CMD            "cmd"
 #define ARGUMENT_CONFIG_MOUSE_MOD_CTRL           "ctrl"
 #define ARGUMENT_CONFIG_MOUSE_MOD_FN             "fn"
+#define ARGUMENT_CONFIG_MOUSE_MOD_SUPER          "super"
 #define ARGUMENT_CONFIG_MOUSE_ACTION_MOVE        "move"
 #define ARGUMENT_CONFIG_MOUSE_ACTION_MOVE_LEGACY "move2"
 #define ARGUMENT_CONFIG_MOUSE_ACTION_RESIZE      "resize"
@@ -720,6 +721,8 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
             g_mouse_state.modifier = MOUSE_MOD_CTRL;
         } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_MOD_FN)) {
             g_mouse_state.modifier = MOUSE_MOD_FN;
+        } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_MOD_SUPER)) {
+            g_mouse_state.modifier = MOUSE_MOD_SUPER;
         } else {
             daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
         }

--- a/src/message.c
+++ b/src/message.c
@@ -47,23 +47,24 @@ extern bool g_verbose;
 
 #define SELECTOR_CONFIG_SPACE                "--space"
 
-#define ARGUMENT_CONFIG_FFM_AUTOFOCUS        "autofocus"
-#define ARGUMENT_CONFIG_FFM_AUTORAISE        "autoraise"
-#define ARGUMENT_CONFIG_WINDOW_PLACEMENT_FST "first_child"
-#define ARGUMENT_CONFIG_WINDOW_PLACEMENT_SND "second_child"
-#define ARGUMENT_CONFIG_SHADOW_FLT           "float"
-#define ARGUMENT_CONFIG_LAYOUT_BSP           "bsp"
-#define ARGUMENT_CONFIG_LAYOUT_FLOAT         "float"
-#define ARGUMENT_CONFIG_MOUSE_MOD_ALT        "alt"
-#define ARGUMENT_CONFIG_MOUSE_MOD_SHIFT      "shift"
-#define ARGUMENT_CONFIG_MOUSE_MOD_CMD        "cmd"
-#define ARGUMENT_CONFIG_MOUSE_MOD_CTRL       "ctrl"
-#define ARGUMENT_CONFIG_MOUSE_MOD_FN         "fn"
-#define ARGUMENT_CONFIG_MOUSE_ACTION_MOVE    "move"
-#define ARGUMENT_CONFIG_MOUSE_ACTION_RESIZE  "resize"
-#define ARGUMENT_CONFIG_EXTERNAL_BAR_MAIN    "main"
-#define ARGUMENT_CONFIG_EXTERNAL_BAR_ALL     "all"
-#define ARGUMENT_CONFIG_EXTERNAL_BAR         "%5[^:]:%d:%d"
+#define ARGUMENT_CONFIG_FFM_AUTOFOCUS            "autofocus"
+#define ARGUMENT_CONFIG_FFM_AUTORAISE            "autoraise"
+#define ARGUMENT_CONFIG_WINDOW_PLACEMENT_FST     "first_child"
+#define ARGUMENT_CONFIG_WINDOW_PLACEMENT_SND     "second_child"
+#define ARGUMENT_CONFIG_SHADOW_FLT               "float"
+#define ARGUMENT_CONFIG_LAYOUT_BSP               "bsp"
+#define ARGUMENT_CONFIG_LAYOUT_FLOAT             "float"
+#define ARGUMENT_CONFIG_MOUSE_MOD_ALT            "alt"
+#define ARGUMENT_CONFIG_MOUSE_MOD_SHIFT          "shift"
+#define ARGUMENT_CONFIG_MOUSE_MOD_CMD            "cmd"
+#define ARGUMENT_CONFIG_MOUSE_MOD_CTRL           "ctrl"
+#define ARGUMENT_CONFIG_MOUSE_MOD_FN             "fn"
+#define ARGUMENT_CONFIG_MOUSE_ACTION_MOVE        "move"
+#define ARGUMENT_CONFIG_MOUSE_ACTION_MOVE_LEGACY "move2"
+#define ARGUMENT_CONFIG_MOUSE_ACTION_RESIZE      "resize"
+#define ARGUMENT_CONFIG_EXTERNAL_BAR_MAIN        "main"
+#define ARGUMENT_CONFIG_EXTERNAL_BAR_ALL         "all"
+#define ARGUMENT_CONFIG_EXTERNAL_BAR             "%5[^:]:%d:%d"
 /* ----------------------------------------------------------------------------- */
 
 /* --------------------------------DOMAIN DISPLAY------------------------------- */
@@ -728,6 +729,8 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
             fprintf(rsp, "%s\n", mouse_mode_str[g_mouse_state.action1]);
         } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_ACTION_MOVE)) {
             g_mouse_state.action1 = MOUSE_MODE_MOVE;
+        } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_ACTION_MOVE_LEGACY)) {
+            g_mouse_state.action1 = MOUSE_MODE_MOVE_LEGACY;
         } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_ACTION_RESIZE)) {
             g_mouse_state.action1 = MOUSE_MODE_RESIZE;
         } else {
@@ -739,6 +742,8 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
             fprintf(rsp, "%s\n", mouse_mode_str[g_mouse_state.action2]);
         } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_ACTION_MOVE)) {
             g_mouse_state.action2 = MOUSE_MODE_MOVE;
+        } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_ACTION_MOVE_LEGACY)) {
+            g_mouse_state.action2 = MOUSE_MODE_MOVE_LEGACY;
         } else if (token_equals(value, ARGUMENT_CONFIG_MOUSE_ACTION_RESIZE)) {
             g_mouse_state.action2 = MOUSE_MODE_RESIZE;
         } else {

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -15,6 +15,7 @@ enum mouse_mode
 {
     MOUSE_MODE_NONE,
     MOUSE_MODE_MOVE,
+    MOUSE_MODE_MOVE_LEGACY,
     MOUSE_MODE_RESIZE,
 };
 
@@ -43,9 +44,10 @@ static char *mouse_mod_str[] =
 
 static char *mouse_mode_str[] =
 {
-    [MOUSE_MODE_NONE]   = "none",
-    [MOUSE_MODE_MOVE]   = "move",
-    [MOUSE_MODE_RESIZE] = "resize"
+    [MOUSE_MODE_NONE]        = "none",
+    [MOUSE_MODE_MOVE]        = "move",
+    [MOUSE_MODE_MOVE_LEGACY] = "move2",
+    [MOUSE_MODE_RESIZE]      = "resize"
 };
 
 static uint8_t mouse_mod_from_cgflags(uint32_t cgflags)

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -1,6 +1,9 @@
 #ifndef MOUSE_H
 #define MOUSE_H
 
+#define MOUSE_MOD_FLAG_MIN 0x02
+#define MOUSE_MOD_FLAG_MAX 0x20
+
 enum mouse_mod
 {
     MOUSE_MOD_NONE  = 0x01,

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -8,7 +8,8 @@ enum mouse_mod
     MOUSE_MOD_SHIFT = 0x04,
     MOUSE_MOD_CMD   = 0x08,
     MOUSE_MOD_CTRL  = 0x10,
-    MOUSE_MOD_FN    = 0x20
+    MOUSE_MOD_FN    = 0x20,
+    MOUSE_MOD_SUPER = MOUSE_MOD_ALT | MOUSE_MOD_SHIFT | MOUSE_MOD_CMD | MOUSE_MOD_CTRL,
 };
 
 enum mouse_mode
@@ -40,6 +41,7 @@ static char *mouse_mod_str[] =
     [MOUSE_MOD_CMD]   = "cmd",
     [MOUSE_MOD_CTRL]  = "ctrl",
     [MOUSE_MOD_FN]    = "fn",
+    [MOUSE_MOD_SUPER] = "super",
 };
 
 static char *mouse_mode_str[] =

--- a/src/osax/common.h
+++ b/src/osax/common.h
@@ -1,7 +1,7 @@
 #ifndef SA_COMMON_H
 #define SA_COMMON_H
 
-#define OSAX_VERSION                "1.0.16"
+#define OSAX_VERSION                "1.0.17"
 
 #define OSAX_PAYLOAD_SUCCESS        0
 #define OSAX_PAYLOAD_NOT_FOUND      1

--- a/src/osax/common.h
+++ b/src/osax/common.h
@@ -1,7 +1,7 @@
 #ifndef SA_COMMON_H
 #define SA_COMMON_H
 
-#define OSAX_VERSION                "1.0.15"
+#define OSAX_VERSION                "1.0.16"
 
 #define OSAX_PAYLOAD_SUCCESS        0
 #define OSAX_PAYLOAD_NOT_FOUND      1

--- a/src/osax/payload.m
+++ b/src/osax/payload.m
@@ -377,8 +377,8 @@ static void init_instances()
 {
     // TODO(koekeishiya): Do proper version checks with minor and patch version..
     NSOperatingSystemVersion os_version = [[NSProcessInfo processInfo] operatingSystemVersion];
-    if (os_version.minorVersion != 13 && os_version.minorVersion != 14 && os_version.minorVersion != 15) {
-        NSLog(@"[yabai-sa] spaces functionality is only supported on macOS High Sierra, Mojave and Catalina!");
+    if (os_version.minorVersion != 13 && os_version.minorVersion != 14 && os_version.minorVersion != 15 && os_version.minorVersion != 16) {
+        NSLog(@"[yabai-sa] spaces functionality is only supported on macOS High Sierra, Mojave, Catalina and Big Sur!");
         return;
     }
 

--- a/src/osax/payload.m
+++ b/src/osax/payload.m
@@ -202,7 +202,9 @@ uint64_t get_dppm_offset(NSOperatingSystemVersion os_version) {
 }
 
 uint64_t get_add_space_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 15) {
+    if (os_version.minorVersion == 16) {
+        return 0x230000;
+    } else if (os_version.minorVersion == 15) {
         return 0x230000;
     } else if (os_version.minorVersion == 14) {
         return 0x27e500;


### PR DESCRIPTION
This pull request makes two main changes:

1. Add `move2` option to mouse actions, which uses a less performant approach but which does not rely on scripting-addition, as detailed [here](https://github.com/koekeishiya/yabai/issues/468).
2. Allow mouse action modifiers to be composed, using `+` as a delimiter, for example `cmd+shift+fn`. Also provides `super` for `cmd+alt+shift+ctrl`.