### PR TITLE
Fix Big Sur beta 3 version check

### DIFF
--- a/src/osax/payload.m
+++ b/src/osax/payload.m
@@ -172,7 +172,7 @@ loop:
 }
 
 uint64_t get_dock_spaces_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return 0x9000;
     } if (os_version.minorVersion == 15) {
         return 0x8000;
@@ -189,7 +189,7 @@ uint64_t get_dock_spaces_offset(NSOperatingSystemVersion os_version) {
 }
 
 uint64_t get_dppm_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return 0x8000;
     } else if (os_version.minorVersion == 15) {
         return 0x6000;
@@ -202,7 +202,7 @@ uint64_t get_dppm_offset(NSOperatingSystemVersion os_version) {
 }
 
 uint64_t get_add_space_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return 0x230000;
     } else if (os_version.minorVersion == 15) {
         return 0x230000;
@@ -215,7 +215,7 @@ uint64_t get_add_space_offset(NSOperatingSystemVersion os_version) {
 }
 
 uint64_t get_remove_space_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return 0x2F9000;
     } else if (os_version.minorVersion == 15) {
         return 0x320000;
@@ -228,7 +228,7 @@ uint64_t get_remove_space_offset(NSOperatingSystemVersion os_version) {
 }
 
 uint64_t get_move_space_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return 0x2E9000;
     } else if (os_version.minorVersion == 15) {
         return 0x310000;
@@ -247,7 +247,7 @@ uint64_t get_move_space_offset(NSOperatingSystemVersion os_version) {
 }
 
 uint64_t get_set_front_window_offset(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return 0x53000;
     } else if (os_version.minorVersion == 15) {
         return 0x53000;
@@ -264,7 +264,7 @@ uint64_t get_set_front_window_offset(NSOperatingSystemVersion os_version) {
 }
 
 const char *get_dock_spaces_pattern(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return "?? ?? ?? 00 49 8B 7D 00 48 8B 35 E4 7B 41 00 44 89 BD 38 FE FF FF 44 89 FA 41 FF D4 48 89 C7 E8 1D 8B 32 00 48 89 85 E8 FD FF FF 48 8B 3D 09 CB 41 00 E8 5C 8A 32 00 48 8B 35 45 7C 41 00 48 89 C7 31 D2 41 FF D4 48 89 85 28 FE FF FF 49 8B 7D 00 48";
     } else if (os_version.minorVersion == 15) {
         if (os_version.patchVersion >= 4) {
@@ -281,7 +281,7 @@ const char *get_dock_spaces_pattern(NSOperatingSystemVersion os_version) {
 }
 
 const char *get_dppm_pattern(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return "?? ?? ?? 00 48 89 C6 E8 ?? ?? ?? 00 4D 85 F6 0F 84 ?? 06 00 00 48 8B 3D ?? ?? ?? 00 48 8B 35 ?? ?? ?? 00 FF 15 ?? ?? ?? 00 48 89 C7 E8 ?? ?? ?? 00 48 89 85 08 FF FF FF C7 85 1C FF FF FF 00 00 00 00 E8 ?? ?? ?? 00 48 8D 75 B0 89 C7 E8 ?? ?? ?? 00";
     } else if (os_version.minorVersion == 15) {
         return "?? ?? ?? 00 48 89 C6 E8 ?? ?? ?? 00 4D 85 F6 0F 84 ?? 06 00 00 48 8B 3D ?? ?? ?? 00 48 8B 35 ?? ?? ?? 00 FF 15 ?? ?? ?? 00 48 89 C7 E8 ?? ?? ?? 00 48 89 85 08 FF FF FF C7 85 1C FF FF FF 00 00 00 00 E8 ?? ?? ?? 00 48 8D 75 B0 89 C7 E8 ?? ?? ?? 00";
@@ -294,7 +294,7 @@ const char *get_dppm_pattern(NSOperatingSystemVersion os_version) {
 }
 
 const char *get_add_space_pattern(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC 18 4C 89 6D C0 48 BA 01 00 00 00 00 00 00 40 48 B9 F8 FF FF FF FF FF FF 00 49 8D 45 28 48 89 45 D0 4D 8B 7D 28 41 80 7D 38 01 48 89 7D C8 75 2E 49 89 FC 49 85 D7 74 59 4C 89 FB 48 21 CB 41 F6 C7 01 49 0F 45 DF 4C 89 FF E8 18 FC 0F 00 48 89 DF E8 62";
     } else if (os_version.minorVersion == 15) {
         if (os_version.patchVersion >= 4) {
@@ -315,7 +315,7 @@ const char *get_add_space_pattern(NSOperatingSystemVersion os_version) {
 }
 
 const char *get_remove_space_pattern(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
             return "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC 68 48 89 4D 98 49 89 D4 49 89 F6 49 89 FF 49 89 F5 E8 9A 93 F3 FF 49 89 C5 48 B8 01 00 00 00 00 00 00 40 49 85 C5 0F 85 DE 03 00 00 48 B8 F8 FF FF FF FF FF FF 00 4C 21 E8 48 8B 58 10 48 83 FB 02 0F 8C CD 01 00 00 4C 89 75 A0 48 8D 05 C6 F6 13 00 48 8B 00 4D 8B 34 07 4C 89 E3 4D 8B 64 07";
     } else if (os_version.minorVersion == 15) {
         if (os_version.patchVersion >= 4) {
@@ -336,7 +336,7 @@ const char *get_remove_space_pattern(NSOperatingSystemVersion os_version) {
 }
 
 const char *get_move_space_pattern(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC 48 4C 89 E9 41 89 D5 49 89 F6 49 89 FF 48 8D 1D 0C EA 14 00 48 8B 03 4C 8B 24 07 4C 89 E7 48 89 4D A0 48 89 CE E8 D6 C0 00 00 48 85 C0 74 27 48 8D 0D 0E DD 15 00 80 39 01 48 89 55 C8 48 89 45 A8 75 1A 48 89 C7 4C 89 F6 49 89 D5 E8 6F D8 F4";
     } else if (os_version.minorVersion == 15) {
         if (os_version.patchVersion >= 4) {
@@ -359,7 +359,7 @@ const char *get_move_space_pattern(NSOperatingSystemVersion os_version) {
 }
 
 const char *get_set_front_window_pattern(NSOperatingSystemVersion os_version) {
-    if (os_version.minorVersion == 16) {
+    if (os_version.majorVersion == 11) {
         return "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC 58 48 8B 05 ?? ?? ?? 00 48 8B 00 48 89 45 D0 85 F6 0F 84 ?? 02 00 00 41 89 F5 49 89 FF 49 89 FE 49 C1 EE 20 48 8D 75 AF C6 06 00 E8 ?? ?? 02 00 48 8B 3D ?? ?? ?? 00 BE 01 00 00 00 E8 ?? ?? ?? 00 84 C0 74 59 0F B6 5D AF 4C 8D 45";
     } else if (os_version.minorVersion == 15) {
         return "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 83 EC 58 48 8B 05 ?? ?? ?? 00 48 8B 00 48 89 45 D0 85 F6 0F 84 ?? 02 00 00 41 89 F5 49 89 FF 49 89 FE 49 C1 EE 20 48 8D 75 AF C6 06 00 E8 ?? ?? 02 00 48 8B 3D ?? ?? ?? 00 BE 01 00 00 00 E8 ?? ?? ?? 00 84 C0 74 59 0F B6 5D AF 4C 8D 45";

--- a/src/osax/sa.m
+++ b/src/osax/sa.m
@@ -110,7 +110,7 @@ static char sa_bundle_plist[] =
 static void scripting_addition_set_path(void)
 {
     NSOperatingSystemVersion os_version = [[NSProcessInfo processInfo] operatingSystemVersion];
-    if (os_version.minorVersion >= 14) {
+    if (os_version.majorVersion == 11 || os_version.minorVersion >= 14) {
         snprintf(osax_base_dir, sizeof(osax_base_dir), "%s", "/Library/ScriptingAdditions/yabai.osax");
     } else {
         snprintf(osax_base_dir, sizeof(osax_base_dir), "%s", "/System/Library/ScriptingAdditions/yabai.osax");


### PR DESCRIPTION
As of developer beta 3, the OS version is always set to 11.0 instead of the 10.16 it was set to previously. This fixes various checks in the code base. It does not, however, fix the actual signatures for beta 3 (currently, `osax_attrib = 0`, current Dock.app is in #589).