### PR TITLE
Ignore all AXUnknown* windows

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -439,7 +439,7 @@ bool window_is_unknown(struct window *window)
     CFStringRef subrole = window_subrole(window);
     if (!subrole) return false;
 
-    bool result = CFEqual(subrole, kAXUnknownSubrole);
+    bool result = CFStringHasPrefix(subrole, kAXUnknownSubrole);
     CFRelease(subrole);
 
     return result;


### PR DESCRIPTION
Checks for `AXUnknown` as a prefix to also ignore Hammerspoon windows created by drawing with [hs.canvas](https://www.hammerspoon.org/docs/hs.canvas.html) which always have `AXUnknown.Hammerspoon` as their subrole.

This will clean up the window query results and fix the issue of wrongly recreating the stack indicators on the `window_destroyed` event: https://github.com/AdamWagner/stackline/pull/14