### PR TITLE
use mach API to inject payload on Big Sur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
 /archive
+/src/osax/sa_mach_bootstrap.c
 /src/osax/sa_loader.c
 /src/osax/sa_payload.c

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ SCRIPT_PATH    = ./scripts
 ASSET_PATH     = ./assets
 SMP_PATH       = ./examples
 ARCH_PATH      = ./archive
-OSAX_SRC       = ./src/osax/sa_loader.c ./src/osax/sa_payload.c
+OSAX_SRC       = ./src/osax/sa_loader.c ./src/osax/sa_payload.c ./src/osax/sa_mach_bootstrap.c
 YABAI_SRC      = ./src/manifest.m $(OSAX_SRC)
 OSAX_PATH      = ./src/osax
 BINS           = $(BUILD_PATH)/yabai
@@ -19,13 +19,16 @@ all: clean-build $(BINS)
 install: BUILD_FLAGS=-std=c99 -Wall -DNDEBUG -O2 -fvisibility=hidden -mmacosx-version-min=10.13
 install: clean-build $(BINS)
 
-$(OSAX_SRC): $(OSAX_PATH)/loader.m $(OSAX_PATH)/payload.m
+$(OSAX_SRC): $(OSAX_PATH)/loader.m $(OSAX_PATH)/payload.m $(OSAX_PATH)/mach_bootstrap.c
 	clang $(OSAX_PATH)/loader.m -shared -O2 -mmacosx-version-min=10.13 -o $(OSAX_PATH)/loader -framework Cocoa
 	clang $(OSAX_PATH)/payload.m -DOBJC_OLD_DISPATCH_PROTOTYPES=1 -shared -fPIC -O2 -mmacosx-version-min=10.13 -o $(OSAX_PATH)/payload -framework Cocoa -framework Carbon
+	clang $(OSAX_PATH)/mach_bootstrap.c -shared -fPIC -O2 -mmacosx-version-min=10.13 -o $(OSAX_PATH)/mach_bootstrap -framework Carbon -lpthread
 	xxd -i -a $(OSAX_PATH)/loader $(OSAX_PATH)/sa_loader.c
 	xxd -i -a $(OSAX_PATH)/payload $(OSAX_PATH)/sa_payload.c
+	xxd -i -a $(OSAX_PATH)/mach_bootstrap $(OSAX_PATH)/sa_mach_bootstrap.c
 	rm -f $(OSAX_PATH)/loader
 	rm -f $(OSAX_PATH)/payload
+	rm -f $(OSAX_PATH)/mach_bootstrap
 
 man:
 	asciidoctor -b manpage $(DOC_PATH)/yabai.asciidoc -o $(DOC_PATH)/yabai.1

--- a/src/manifest.m
+++ b/src/manifest.m
@@ -34,6 +34,7 @@
 #include "misc/socket.c"
 
 #include "osax/sa.h"
+#include "osax/mach_loader.c"
 #include "osax/sa.m"
 
 #include "event.h"

--- a/src/osax/common.h
+++ b/src/osax/common.h
@@ -1,7 +1,7 @@
 #ifndef SA_COMMON_H
 #define SA_COMMON_H
 
-#define OSAX_VERSION                "1.0.22"
+#define OSAX_VERSION                "1.0.25"
 
 #define OSAX_PAYLOAD_SUCCESS        0
 #define OSAX_PAYLOAD_NOT_FOUND      1

--- a/src/osax/mach_bootstrap.c
+++ b/src/osax/mach_bootstrap.c
@@ -1,0 +1,44 @@
+#include <mach/mach.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <dlfcn.h>
+
+extern void _pthread_set_self(char *);
+
+static void drop_privileges(void)
+{
+    if (geteuid() == 0) {
+        setgid(getgid());
+        setuid(getuid());
+    }
+}
+
+static void *mach_load_payload(void *context)
+{
+    drop_privileges();
+
+    void *handle = dlopen("/Library/ScriptingAdditions/yabai.osax/Contents/Resources/payload.bundle/Contents/MacOS/payload", RTLD_NOW);
+    if (!handle) dlerror();
+
+    return NULL;
+}
+
+void mach_bootstrap_entry_point(char *param)
+{
+    int policy;
+    pthread_t thread;
+    pthread_attr_t attr;
+    struct sched_param sched;
+
+    _pthread_set_self(param);
+    pthread_attr_init(&attr);
+    pthread_attr_getschedpolicy(&attr, &policy);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+    sched.sched_priority = sched_get_priority_max(policy);
+    pthread_attr_setschedparam(&attr, &sched);
+    pthread_create(&thread, &attr, &mach_load_payload, NULL);
+    pthread_attr_destroy(&attr);
+
+    thread_suspend(mach_thread_self());
+}

--- a/src/osax/mach_loader.c
+++ b/src/osax/mach_loader.c
@@ -1,0 +1,103 @@
+#include <mach-o/dyld.h>
+#include <mach-o/getsect.h>
+#include <mach/mach.h>
+#include <dlfcn.h>
+
+static bool mach_loader_lookup_image(void *ptr, void **image, uint64_t *image_size)
+{
+    uint64_t addr = (uint64_t) ptr;
+    int count = _dyld_image_count();
+
+    for (int i = 0; i < count; ++i) {
+        const struct mach_header_64 *header = (const struct mach_header_64 *) _dyld_get_image_header(i);
+        const struct section_64 *section = getsectbynamefromheader_64(header, SEG_TEXT, SECT_TEXT);
+        if (!section) continue;
+
+        uint64_t start = section->addr + _dyld_get_image_vmaddr_slide(i);
+        uint64_t stop = start + section->size;
+
+        if (addr >= start && addr <= stop) {
+            const char *name = _dyld_get_image_name(i);
+
+            struct stat sb;
+            if (stat(name, &sb)) return false;
+
+            *image = (void *) header;
+            *image_size = sb.st_size;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool mach_loader_inject_payload(pid_t pid)
+{
+    mach_port_t task = 0;
+    thread_act_t thread = 0;
+    x86_thread_state64_t thread_state = {};
+    void *image = 0;
+    uint64_t image_size = 0;
+    vm_address_t code = 0;
+    vm_address_t stack = 0;
+    vm_size_t stack_size = 16 * 1024;
+    uint64_t stack_contents = 0x00000000CAFEBABE;
+
+    void *bootstrap_handle = dlopen("/Library/ScriptingAdditions/yabai.osax/Contents/MacOS/mach_bootstrap", RTLD_NOW);
+    if (!bootstrap_handle) {
+        fprintf(stderr, "could not load bootstrap object file\n");
+        return false;
+    }
+
+    void *bootstrap_entry = dlsym(bootstrap_handle, "mach_bootstrap_entry_point");
+    if (!bootstrap_entry) {
+        fprintf(stderr, "could not load bootstrap entry point\n");
+        return false;
+    }
+
+    if (task_for_pid(mach_task_self(), pid, &task) != KERN_SUCCESS) {
+        fprintf(stderr, "could not retrieve task port for pid: %d\n", pid);
+        return false;
+    }
+
+    if (vm_allocate(task, &stack, stack_size, 1) != KERN_SUCCESS) {
+        fprintf(stderr, "could not allocate stack segment\n");
+        return false;
+    }
+
+    if (!mach_loader_lookup_image(bootstrap_entry, &image, &image_size)) {
+        fprintf(stderr, "could not locate bootstrap image\n");
+        return false;
+    }
+
+    if (vm_allocate(task, &code, image_size, 1) != KERN_SUCCESS) {
+        fprintf(stderr, "could not allocate code segment\n");
+        return false;
+    }
+
+    if (vm_protect(task, code, image_size, 0, VM_PROT_EXECUTE | VM_PROT_WRITE | VM_PROT_READ) != KERN_SUCCESS) {
+        fprintf(stderr, "could not change protection for code segment\n");
+        return false;
+    }
+
+    if (vm_write(task, code, (pointer_t)image, image_size) != KERN_SUCCESS) {
+        fprintf(stderr, "could not copy image into code segment\n");
+        return false;
+    }
+
+    if (vm_write(task, stack, (pointer_t) &stack_contents, sizeof(uint64_t)) != KERN_SUCCESS) {
+        fprintf(stderr, "could not copy dummy return address into stack segment\n");
+        return false;
+    }
+
+    thread_state.__rdi = (uint64_t) stack;
+    thread_state.__rip = (uint64_t) code + (uint64_t)(((void *) bootstrap_entry) - image);
+    thread_state.__rsp = (uint64_t) (stack + (stack_size / 2) - 8);
+
+    if (thread_create_running(task, x86_THREAD_STATE64, (thread_state_t)&thread_state, x86_THREAD_STATE64_COUNT, &thread) != KERN_SUCCESS) {
+        fprintf(stderr, "could not spawn remote thread\n");
+        return false;
+    }
+
+    return true;
+}

--- a/src/osax/payload.m
+++ b/src/osax/payload.m
@@ -1036,12 +1036,7 @@ static bool start_daemon(char *socket_path)
     return true;
 }
 
-@interface Payload : NSObject
-+ (void) load;
-@end
-
-@implementation Payload
-+ (void) load
+void load_payload(void)
 {
     NSLog(@"[yabai-sa] loaded payload");
     init_instances();
@@ -1065,5 +1060,15 @@ static bool start_daemon(char *socket_path)
     } else {
         NSLog(@"[yabai-sa] failed to spawn thread..");
     }
+}
+
+@interface Payload : NSObject
++ (void) load;
+@end
+
+@implementation Payload
++ (void) load
+{
+    load_payload();
 }
 @end

--- a/src/osax/sa.h
+++ b/src/osax/sa.h
@@ -28,6 +28,9 @@ bool scripting_addition_set_shadow(uint32_t wid, bool shadow);
 bool scripting_addition_focus_window(uint32_t wid);
 bool scripting_addition_scale_window(uint32_t wid, float x, float y, float w, float h);
 
+extern bool workspace_is_macos_bigsur(void);
+extern unsigned char __src_osax_mach_bootstrap[];
+extern unsigned int __src_osax_mach_bootstrap_len;
 extern unsigned char __src_osax_loader[];
 extern unsigned int __src_osax_loader_len;
 extern unsigned char __src_osax_payload[];

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -17,6 +17,7 @@ bool workspace_application_is_observable(struct process *process);
 bool workspace_application_is_finished_launching(struct process *process);
 void workspace_application_observe_finished_launching(void *context, struct process *process);
 void workspace_application_observe_activation_policy(void *context, struct process *process);
+bool workspace_is_macos_bigsur(void);
 bool workspace_is_macos_catalina(void);
 
 #endif

--- a/src/workspace.m
+++ b/src/workspace.m
@@ -101,6 +101,12 @@ bool workspace_application_is_finished_launching(struct process *process)
     }
 }
 
+bool workspace_is_macos_bigsur(void)
+{
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    return version.majorVersion == 11;
+}
+
 bool workspace_is_macos_catalina(void)
 {
     NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];

--- a/src/workspace.m
+++ b/src/workspace.m
@@ -104,7 +104,7 @@ bool workspace_application_is_finished_launching(struct process *process)
 bool workspace_is_macos_bigsur(void)
 {
     NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-    return version.majorVersion == 11;
+    return (version.majorVersion == 11) || (version.majorVersion == 10 && version.minorVersion == 16);
 }
 
 bool workspace_is_macos_catalina(void)

--- a/src/yabai.c
+++ b/src/yabai.c
@@ -300,10 +300,12 @@ int main(int argc, char **argv)
         error("yabai: could not initialize daemon! abort..\n");
     }
 
-    if (scripting_addition_is_installed()) {
-        scripting_addition_load();
-    } else {
-        notify("scripting-addition", "payload is not installed, some features will not work!");
+    if (!workspace_is_macos_bigsur()) {
+        if (scripting_addition_is_installed()) {
+            scripting_addition_load();
+        } else {
+            notify("scripting-addition", "payload is not installed, some features will not work!");
+        }
     }
 
     exec_config_file();


### PR DESCRIPTION
This branch uses the mach API instead of the scripting-bridge framework to inject the payload into Dock.app on macOS Big Sur. Yabai will no longer be able to automatically load the payload upon startup, because the injection has to be performed as the root user. The following steps can be used to test this:

1. Clone this branch and run `make clean && make install`
2. install osax: `sudo yabai --install-sa`
3. Open Console.app and filter messages for `yabai-sa`
4. load osax: `sudo yabai --load-sa`
5. Check the log inside Console.app to see if the injection succeeded. Should look something like this: 
![Screenshot 2020-10-03 at 13 55 26](https://user-images.githubusercontent.com/6175959/94990993-60a04100-0580-11eb-8604-ee2e9e48c06d.png)
