### PR TITLE
fix focus and border on managed windows

### DIFF
--- a/src/border.c
+++ b/src/border.c
@@ -67,7 +67,7 @@ void border_create(struct window *window)
 {
     if (window->border.id) return;
 
-    if ((!window_is_standard(window)) && (!window_is_dialog(window))) return;
+    if ((!window_is_standard(window) && !window->rule_manage) && (!window_is_dialog(window))) return;
 
     CGRect frame = window_ax_frame(window);
     CGSNewRegionWithRect(&frame, &window->border.region);

--- a/src/event.c
+++ b/src/event.c
@@ -775,9 +775,9 @@ static EVENT_CALLBACK(EVENT_HANDLER_MOUSE_MOVED)
 
     struct window *window = window_manager_find_window_at_point(&g_window_manager, point);
     if (window) {
-        if (window->id == g_window_manager.focused_window_id) return EVENT_SUCCESS;
-        if (!window_level_is_standard(window))                return EVENT_SUCCESS;
-        if (!window_is_standard(window))                      return EVENT_SUCCESS;
+        if (window->id == g_window_manager.focused_window_id)       return EVENT_SUCCESS;
+        if (!window_level_is_standard(window))                      return EVENT_SUCCESS;
+        if (!window_is_standard(window) && !window->rule_manage)    return EVENT_SUCCESS;
 
         if (g_window_manager.ffm_mode == FFM_AUTOFOCUS) {
 


### PR DESCRIPTION
Hi!

I use Adobe After Effects, and I think it's window type is weird so it doesn't get borders / auto focus.
It also doesn't tile automatically.

I worked around it not tiling by forcing "manage=on" with a signal:

```
yabai -m rule --add app="^Adobe After Effects (Beta)*" manage=on border=on
```

However, the border and auto focus still didn't work.

Let me know if this is the correct fix for this.

closes #788