### PR TITLE
Reinitialize NSRunningApplication at EVENT_HANDLER_APPLICATION_LAUNCHED

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -46,6 +46,7 @@ static void window_did_receive_focus(struct window_manager *wm, struct mouse_sta
 static EVENT_CALLBACK(EVENT_HANDLER_APPLICATION_LAUNCHED)
 {
     struct process *process = context;
+    process->ns_application = workspace_application_create_running_ns_application(process); 
 
     if (process->terminated) {
         debug("%s: %s (%d) terminated during launch\n", __FUNCTION__, process->name, process->pid);


### PR DESCRIPTION
As per https://github.com/koekeishiya/yabai/issues/923#issuecomment-885823553 this appears to resolve #920 crashes for me  

(all the ones I have experienced so far anyway, there may be more like it)

I'm not asserting this is the _correct_ way to handle this, but its a workaround at least

(Also my literal test case is as xorpse#5 )