### PR TITLE
Avoid displaced borders after some window moves

### DIFF
--- a/src/border.c
+++ b/src/border.c
@@ -105,7 +105,9 @@ void border_resize(struct window *window)
     if (!window->border.id) return;
 
     CGRect frame = window_ax_frame(window);
-    if ((frame.size.width  == window->border.frame.size.width) &&
+    if ((frame.origin.x  == window->border.frame.origin.x) &&
+        (frame.origin.y == window->border.frame.origin.y) &&
+        (frame.size.width  == window->border.frame.size.width) &&
         (frame.size.height == window->border.frame.size.height)) return;
 
     if (window->border.region) CFRelease(window->border.region);

--- a/src/view.c
+++ b/src/view.c
@@ -311,8 +311,10 @@ void window_node_flush(struct window_node *node)
             if (window) {
                 if (node->zoom) {
                     window_manager_set_window_frame(window, node->zoom->area.x, node->zoom->area.y, node->zoom->area.w, node->zoom->area.h);
+                    border_resize(window);
                 } else {
                     window_manager_set_window_frame(window, node->area.x, node->area.y, node->area.w, node->area.h);
+                    border_resize(window);
                 }
             }
         }


### PR DESCRIPTION
I (again M1, monterey beta 3, @xorpse's fork, so YMMV) have been experiencing an annoying behavior where if I move a window (by click and drop, either with yabai `mouse_modifier` or just dragging on the native title bar) and drop it such that it doesn't actually move*, the window content snaps back to where it should be tiled, but the border remains where it was moved to:

![CleanShot 2021-08-03 at 17 28 26@2x](https://user-images.githubusercontent.com/43136/128090060-e1caaf68-ee76-4c3e-bfd8-25b43b4005e3.png)

This patch gets rid of this behavior (but probably isn't quite right yet)



*(and I'm 99% sure I've also seen on some valid swaps as well, but failed to repro when I was looking to screenshot)