### PR TITLE
fix borders for monterey

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -372,6 +372,11 @@ struct window_node *window_node_find_first_leaf(struct window_node *root)
 {
     struct window_node *node = root;
     while (!window_node_is_leaf(node)) {
+        if (node->right && node->right->zoom == node) {
+          node = node->right;
+          break;
+        }
+
         node = node->left;
     }
     return node;

--- a/src/window_manager.c
+++ b/src/window_manager.c
@@ -415,9 +415,11 @@ void window_manager_move_window(struct window *window, float x, float y)
     CFTypeRef position_ref = AXValueCreate(kAXValueTypeCGPoint, (void *) &position);
     if (!position_ref) return;
 
+    if (window->border.id) scripting_addition_remove_from_window_group(window->border.id, window->id);
     if (AXUIElementSetAttributeValue(window->ref, kAXPositionAttribute, position_ref) == kAXErrorSuccess) {
         if (window->border.id) SLSMoveWindow(g_connection, window->border.id, &position);
     }
+    if (window->border.id) scripting_addition_add_to_window_group(window->border.id, window->id);
 
     CFRelease(position_ref);
 }


### PR DESCRIPTION
The window movement groups for the borders clash with the window movement via AX on Monterey leading to freezes etc.