### PR TITLE
Master Layout 

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -61,6 +61,7 @@ extern bool g_verbose;
 #define ARGUMENT_CONFIG_WINDOW_PLACEMENT_SND  "second_child"
 #define ARGUMENT_CONFIG_SHADOW_FLT            "float"
 #define ARGUMENT_CONFIG_LAYOUT_BSP            "bsp"
+#define ARGUMENT_CONFIG_LAYOUT_MASTER         "master"
 #define ARGUMENT_CONFIG_LAYOUT_STACK          "stack"
 #define ARGUMENT_CONFIG_LAYOUT_FLOAT          "float"
 #define ARGUMENT_CONFIG_MOUSE_MOD_ALT         "alt"
@@ -111,6 +112,7 @@ extern bool g_verbose;
 #define ARGUMENT_SPACE_LAYOUT_BSP   "bsp"
 #define ARGUMENT_SPACE_LAYOUT_STACK "stack"
 #define ARGUMENT_SPACE_LAYOUT_FLT   "float"
+#define ARGUMENT_SPACE_LAYOUT_MASTER   "master"
 /* ----------------------------------------------------------------------------- */
 
 /* --------------------------------DOMAIN WINDOW-------------------------------- */
@@ -1288,6 +1290,15 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
                 } else {
                     daemon_fail(rsp, "cannot set layout for a macOS fullscreen space!\n");
                 }
+            } else if (token_equals(value, ARGUMENT_CONFIG_LAYOUT_MASTER)) {
+              if (space_is_user(sel_sid)) {
+                view->layout = VIEW_MASTER;
+                view->custom_layout = true;
+                view_clear(view);
+                /* window_manager_validate_and_check_for_windows_on_space(&g_space_manager, &g_window_manager, sel_sid); */
+              } else {
+                daemon_fail(rsp, "cannot set layout for a macOS fullscreen space!\n");
+              }
             } else {
                 daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
             }
@@ -1300,7 +1311,10 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
                 space_manager_set_layout_for_all_spaces(&g_space_manager, VIEW_STACK);
             } else if (token_equals(value, ARGUMENT_CONFIG_LAYOUT_FLOAT)) {
                 space_manager_set_layout_for_all_spaces(&g_space_manager, VIEW_FLOAT);
-            } else {
+            } else if (token_equals(value, ARGUMENT_CONFIG_LAYOUT_MASTER)) {
+                space_manager_set_layout_for_all_spaces(&g_space_manager, VIEW_MASTER);
+            }
+            else {
                 daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
             }
         }
@@ -1664,8 +1678,14 @@ static void handle_domain_space(FILE *rsp, struct token domain, char *message)
                 daemon_fail(rsp, "cannot set layout for a macOS fullscreen space!\n");
             }
         } else if (token_equals(value, ARGUMENT_SPACE_LAYOUT_FLT)) {
+          if (space_is_user(acting_sid)) {
+            space_manager_set_layout_for_space(&g_space_manager, acting_sid, VIEW_FLOAT);
+          } else {
+            daemon_fail(rsp, "cannot set layout for a macOS fullscreen space!\n");
+          }
+        } else if (token_equals(value, ARGUMENT_SPACE_LAYOUT_MASTER)) {
             if (space_is_user(acting_sid)) {
-                space_manager_set_layout_for_space(&g_space_manager, acting_sid, VIEW_FLOAT);
+                space_manager_set_layout_for_space(&g_space_manager, acting_sid, VIEW_MASTER);
             } else {
                 daemon_fail(rsp, "cannot set layout for a macOS fullscreen space!\n");
             }

--- a/src/view.h
+++ b/src/view.h
@@ -130,6 +130,7 @@ void view_stack_window_node(struct view *view, struct window_node *node, struct 
 void view_add_window_node(struct view *view, struct window *window);
 void view_remove_window_node(struct view *view, struct window *window);
 uint32_t *view_find_window_list(struct view *view, int *window_count);
+int view_get_window_count(struct view *view);
 
 void view_serialize(FILE *rsp, struct view *view);
 bool view_is_invalid(struct view *view);

--- a/src/view.h
+++ b/src/view.h
@@ -74,6 +74,7 @@ enum view_type
     VIEW_DEFAULT,
     VIEW_BSP,
     VIEW_STACK,
+    VIEW_MASTER,
     VIEW_FLOAT
 };
 
@@ -81,6 +82,7 @@ static const char *view_type_str[] =
 {
     "default",
     "bsp",
+    "master",
     "stack",
     "float"
 };


### PR DESCRIPTION
This PR tries to add master layout to yabai. 

closes #1124 

## Window Model
```
    +------+---------------------+------------+--------+
    |                            |                     |
    |                            |                     |
    |                            |                     |
    |                            |                     |
    |          master            |        stack        |
    |                            |                     |
    |                            |                     |
    |                            |                     |
    |                            |                     |
    +----------------------------+---------------------+
```
additional windows are appended to stack area.

Currently no special logic added, just the fact that new windows are added to the end of the stack.

Issues: 

- [ ] on yabai re-launch the layout get missed up, no longer master window just horizontal split windows
- [ ] Swap/Warp not working because I haven't modified conditions to treat BSP layout as Master layout 

Features:
- [ ] Warp Master: when the focused window is master, `yabai -m window --warp master` should make the next window in the stack master, otherwise the acting_window should be swapped with master.
- [ ] Focus Master: switch focus to master window
- [ ] Focus/move next/prev: currently my custom mappings works but it would nice to just have `-m window --swap/--focus next/prev` would go to first/last is not window next/prev window exists.
- [ ] Increase/decrement master window width: currently I have the following script to make it work, though it would be nice to have something like `yabai -m window --master-area inc/dec`
    ```bash
      local SIZE=$( [[ $1 == "left" ]] && echo "-100:0" || echo "+100:0")
      yabai -m window --resize left:$SIZE || yabai -m window --resize right:$SIZE
    ```

