### PR TITLE
fixed jq command in example skhdrc

### DIFF
--- a/examples/skhdrc
+++ b/examples/skhdrc
@@ -96,7 +96,7 @@
 
 # create desktop, move window and follow focus - uses jq for parsing json (brew install jq)
 # shift + cmd - n : yabai -m space --create && \
-#                   index="$(yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index')" && \
+#                   index="$(yabai -m query --spaces --display | jq 'map(select(."is-native-fullscreen" == false))[-1].index')" && \
 #                   yabai -m window --space "${index}" && \
 #                   yabai -m space --focus "${index}"
 


### PR DESCRIPTION
Some 4.0 changes broke the example configuration.
native-fullscreen changed to is-native-fullscreen
0 changed to false