### PR TITLE
Fix window resizing not always updating layout

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -959,7 +959,15 @@ static EVENT_CALLBACK(EVENT_HANDLER_MOUSE_DOWN)
     CGPoint point = CGEventGetLocation(context);
     debug("%s: %.2f, %.2f\n", __FUNCTION__, point.x, point.y);
 
-    struct window *window = window_manager_find_window_at_point(&g_window_manager, point);
+    struct window *window = NULL;
+    // Matching the event point to the window doesn't always give the window
+    // that the mouse down event *affects* as when resizing using the window
+    // border, because the resize cursor appears at the edge of the focused
+    // window *before* the cursor coordinates are actually inside the window
+    // frame rectangle.
+    int64_t window_id = CGEventGetIntegerValueField(context, kCGMouseEventWindowUnderMousePointerThatCanHandleThisEvent);
+    if (window_id) window = window_manager_find_window(&g_window_manager, window_id);
+    if (!window) window = window_manager_find_window_at_point(&g_window_manager, point);
     if (!window) window = window_manager_focused_window(&g_window_manager);
     if (!window || window_is_fullscreen(window)) goto out;
 

--- a/src/event_tap.c
+++ b/src/event_tap.c
@@ -45,7 +45,10 @@ bool event_tap_begin(struct event_tap *event_tap, uint32_t mask, event_tap_callb
 {
     if (event_tap->handle) return true;
 
-    event_tap->handle = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, mask, callback, event_tap);
+    // Use kCGAnnotatedSessionEventTap so that mouse events carry the window ID they're associated
+    // with, which is needed during resizing, when the border can be grabbed from a coordinate
+    // that is outside the window frame
+    event_tap->handle = CGEventTapCreate(kCGAnnotatedSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, mask, callback, event_tap);
     if (!event_tap->handle) return false;
 
     if (!CGEventTapIsEnabled(event_tap->handle)) {


### PR DESCRIPTION
Fixes #1199: resizing a window didn't always update
the layout split. The underlying reason is that the
mouse down coordinates for window resizing are not
always within the `CGRect` of the window's frame;
often they are just outside the window's frame when
the resize cursor appears.

I changed the event tap location to `kCGAnnotatedSessionEventTap`,
which includes the field `kCGMouseEventWindowUnderMousePointerThatCanHandleThisEvent`
in the event metadata that always accurately identifies the window
that the click affects. This **does** alter the point in the input
stack at which Yabai observes events, but examining `EVENT_TAP_CALLBACK(mouse_handler)`
and user-testing the mouse features seems to show that changing
the observation point does not cause any regression.

I might be wrong about this. Please let me know if changing
the event tap location is a bad idea, and I will try to find
another workaround for this problem.
