### PR TITLE
clamp ratio instead of resetting when overstepping

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -126,7 +126,7 @@ static inline enum window_node_split window_node_get_split(struct window_node *n
 
 static inline float window_node_get_ratio(struct window_node *node)
 {
-    return in_range_ii(node->ratio, 0.1f, 0.9f) ? node->ratio : g_space_manager.split_ratio;
+    return clampf_range(node->ratio, 0.1f, 0.9f);
 }
 
 static inline float window_node_get_gap(struct view *view)

--- a/src/view.c
+++ b/src/view.c
@@ -126,7 +126,7 @@ static inline enum window_node_split window_node_get_split(struct window_node *n
 
 static inline float window_node_get_ratio(struct window_node *node)
 {
-    return clampf_range(node->ratio, 0.1f, 0.9f);
+    return (node->ratio <= 0.0f) ? g_space_manager.split_ratio : clampf_range(node->ratio, 0.1f, 0.9f);
 }
 
 static inline float window_node_get_gap(struct view *view)


### PR DESCRIPTION
Related Issue : https://github.com/koekeishiya/yabai/issues/1401

This is in order to avoid sudden layout shifts when trying to push unimportant windows out of the way.
If trying to resize a window below 10% or above 90%, the ratio will clamp instead of going back to 50%.

Maybe there is a reason to want the reset to 50%, in which case this would need to be optional, I just could not think of one.


Before : 

https://user-images.githubusercontent.com/54172932/190409314-17c15617-012f-4357-b9ac-ae9021ace6e1.mov

After : 

https://user-images.githubusercontent.com/54172932/190409729-26212cd0-9b39-4f52-860a-7634d9416620.mov