### PR TITLE
Minimized windows should not be managed

### DIFF
--- a/src/window_manager.c
+++ b/src/window_manager.c
@@ -296,6 +296,7 @@ void window_manager_center_mouse(struct window_manager *wm, struct window *windo
 bool window_manager_should_manage_window(struct window *window)
 {
     if (window_check_flag(window, WINDOW_FLOAT)) return false;
+    if (window_check_flag(window, WINDOW_MINIMIZE)) return false;
     if (window_is_sticky(window)) return false;
     if (window_rule_check_flag(window, WINDOW_RULE_MANAGED)) return true;
 
@@ -1718,7 +1719,6 @@ static void window_manager_check_for_windows_on_space(struct space_manager *sm, 
     for (int i = 0; i < window_count; ++i) {
         struct window *window = window_manager_find_window(wm, window_list[i]);
         if (!window || !window_manager_should_manage_window(window)) continue;
-        if (window_check_flag(window, WINDOW_MINIMIZE)) continue;
         if (window->application->is_hidden) continue;
 
         struct view *existing_view = window_manager_find_managed_window(wm, window);


### PR DESCRIPTION
Add a check to exclude minimized windows in `window_manager_should_manage_window()`, because minimized windows should not be added to the view. The unminimized event handler will add them to the view when they become visible.

This also removes a check from one call site of `window_manager_should_manage_window()` that also checked whether the window is minimized.

I reviewed all the calling locations, and there is no conditional for which `window_manager_should_manage_window()` is called that *should* handle minimized windows in its body.

Fixes #1418.