### PR TITLE
Fix `area_is_in_direction` on left screens

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -526,10 +526,10 @@ struct window_node *view_find_min_depth_leaf_node(struct window_node *node)
 
 static inline bool area_is_in_direction(struct area *r1, CGPoint r1_max, struct area *r2, CGPoint r2_max, int direction)
 {
-    if (direction == DIR_NORTH && r1_max.y <= r2->y) return false;
-    if (direction == DIR_EAST  && r2_max.x <= r1->x) return false;
-    if (direction == DIR_SOUTH && r2_max.y <= r1->y) return false;
-    if (direction == DIR_WEST  && r1_max.x <= r2->x) return false;
+    if (direction == DIR_NORTH && r1->y <= r2->y) return false;
+    if (direction == DIR_EAST  && r2_max.x <= r1->x + 1) return false;
+    if (direction == DIR_SOUTH && r1->y > r2->y) return false;
+    if (direction == DIR_WEST  && r2_max.x > r1->x + 1) return false;
 
     if (direction == DIR_NORTH || direction == DIR_SOUTH) {
         return ((r2_max.x >  r1->x && r2_max.x <= r1_max.x) ||


### PR DESCRIPTION
I was able to reproduce some of the issues presented in https://github.com/koekeishiya/yabai/issues/1463.

My reasoning for these changes is rather shaky, but I believe some of the calculations may not have taken into account that coordinates on monitors to the left of the main monitor are negative, and that comparing floats with `==` is unpredictable.

Regardless, I've been running with these changes for a few weeks and they seem to solve the problems with `--focus`ing on left monitors.