### PR TITLE
Fix focus follows mouse menu bar detection

### DIFF
--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -207,6 +207,10 @@ CGRect display_manager_menu_bar_rect(uint32_t did)
     bounds.size.width = CGDisplayPixelsWide(did);
 #endif
 
+    CGRect display_frame = CGDisplayBounds(did);
+    bounds.origin.x += display_frame.origin.x;
+    bounds.origin.y += display_frame.origin.y;
+
     return bounds;
 }
 


### PR DESCRIPTION
Fixes https://github.com/koekeishiya/yabai/issues/1857

After doing some debugging and print statements, I noticed that the y coordinate for the mouse is the global y coordinate rather than the local y coordinate to the monitor.

The solution is that the origin of the menu bar rect needs to be offset by the bounding box of the display in question so that it is put in the correct place.

This has been tested and works well on my M2 Macbook Pro.