### PR TITLE
Retry window resize if the frame is not the expected one

### DIFF
--- a/src/window_manager.c
+++ b/src/window_manager.c
@@ -584,6 +584,13 @@ void window_manager_set_window_frame(struct window *window, float x, float y, fl
 
         // NOTE(koekeishiya): Due to macOS constraints (visible screen-area), we might need to resize the window *after* moving it.
         window_manager_resize_window(window, width, height);
+
+        CGRect new_frame = window_ax_frame(window);
+        if (!CGRectEqualToRect((CGRect) {{ x, y }, { width, height }}, new_frame)) {
+            window_manager_resize_window(window, 1, 1);
+            window_manager_move_window(window, x, y);
+            window_manager_resize_window(window, width, height);
+        }
     });
 }
 


### PR DESCRIPTION
Despite the window is resized before and after move, sometimes the resulting frame doesn't match the expected one. I observed this bug specially when windows are close to the display edges.
This PR adds a check after the frame is repositioned and if it doesn't match it will retry by first making the window as small as possible so it doesn't get out of the display while moving.