### PR TITLE
keep layer unchanged during untiling

### DIFF
--- a/src/space_manager.c
+++ b/src/space_manager.c
@@ -124,7 +124,6 @@ void space_manager_untile_window(struct space_manager *sm, struct view *view, st
 {
     if (view->layout == VIEW_FLOAT) return;
 
-    scripting_addition_set_layer(window->id, LAYER_NORMAL);
     struct window_node *node = view_remove_window_node(view, window);
     if (!node) return;
 


### PR DESCRIPTION
When untiling a window, its layer is set to normal which has the effect of it also becoming a "topmost" window, since the default seems to be "below" for all other windows. Resulting in issues like #1929

My suggestion is to not alter the layer during untiling, requiring to set it explicitely.

fwiw: my initial attempt at changing the default layer to `normal`
 didn't work as I expected, but probably that would be a better solution.