### PR TITLE
Ignore notch M1Pro: added '-m config notch' (on/off)

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -100,7 +100,7 @@ CGRect display_bounds_constrained(uint32_t did)
     }
 
     if (display_manager_menu_bar_hidden()) {
-        int notch_height = workspace_display_notch_height(did);
+        int notch_height = g_display_manager.notch ? workspace_display_notch_height(did) : 0;
         if (notch_height > effective_ext_top_padding) {
              frame.origin.y    += (notch_height - effective_ext_top_padding);
              frame.size.height -= (notch_height - effective_ext_top_padding);

--- a/src/display_manager.c
+++ b/src/display_manager.c
@@ -336,5 +336,6 @@ bool display_manager_begin(struct display_manager *dm)
     dm->mode = EXTERNAL_BAR_OFF;
     dm->top_padding = 0;
     dm->bottom_padding = 0;
+    dm->notch = true;
     return CGDisplayRegisterReconfigurationCallback(display_handler, NULL) == kCGErrorSuccess;
 }

--- a/src/display_manager.h
+++ b/src/display_manager.h
@@ -27,6 +27,7 @@ struct display_manager
     int top_padding;
     int bottom_padding;
     enum external_bar_mode mode;
+    bool notch;
 };
 
 bool display_manager_query_displays(FILE *rsp);

--- a/src/message.c
+++ b/src/message.c
@@ -48,6 +48,7 @@ extern bool g_verbose;
 #define COMMAND_CONFIG_MOUSE_ACTION2         "mouse_action2"
 #define COMMAND_CONFIG_MOUSE_DROP_ACTION     "mouse_drop_action"
 #define COMMAND_CONFIG_EXTERNAL_BAR          "external_bar"
+#define COMMAND_CONFIG_NOTCH                 "notch"
 
 #define SELECTOR_CONFIG_SPACE                "--space"
 
@@ -1457,6 +1458,23 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
                 }
             } else {
                 fprintf(rsp, "%s:%d:%d\n", external_bar_mode_str[g_display_manager.mode], g_display_manager.top_padding, g_display_manager.bottom_padding);
+            }
+        } else if (token_equals(command, COMMAND_CONFIG_NOTCH)) {
+            struct token value = get_token(&message);
+            if (!token_is_valid(value)) {
+                fprintf(rsp, "%s\n", bool_str[g_display_manager.notch]);
+            } else if (token_equals(value, ARGUMENT_COMMON_VAL_OFF)) {
+                g_display_manager.notch = false;
+                space_manager_mark_spaces_invalid(&g_space_manager);
+            }
+            else if (token_equals(value, ARGUMENT_COMMON_VAL_ON))
+            {
+                g_display_manager.notch = true;
+                space_manager_mark_spaces_invalid(&g_space_manager);
+            }
+            else
+            {
+                daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
             }
         } else {
             daemon_fail(rsp, "unknown command '%.*s' for domain '%.*s'\n", command.length, command.text, domain.length, domain.text);


### PR DESCRIPTION
Allows you to ignore the macbook m1pro/m2pro notch on compatible apps. Default is on, so no breaking change.
![ezgif-4-1360900ffc](https://github.com/koekeishiya/yabai/assets/113934763/c2994a01-86ab-4790-ae90-99e079810ca4)
