### PR TITLE
Documentation fix

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -151,7 +151,7 @@ Global Settings
 *window_zoom_persist* ['<BOOL_SEL>']::
     Windows will keep their zoom-state through layout changes.
 
-*window_shadow* ['<BOOL_SEL>|float']::
+*window_shadow* ['<BOOL_SEL>']::
     Draw shadow for windows. +
     System Integrity Protection must be partially disabled.
 


### PR DESCRIPTION
It seems that window_shadow can only be on/off.

At least I'm getting

```
unknown value '0.5' given to command 'window_shadow' for domain 'config'
```