### PR TITLE
Minor Doc upgrade

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -731,6 +731,7 @@ COMMAND
 
 *--add event='<EVENT>' action='<ACTION>' [label='<LABEL>'] [app[!]='<REGEX>'] [title[!]='<REGEX>'] [active='yes|no']*::
     Add an optionally labelled signal to execute an action after processing an event of the given type. +
+    Labels need to be unique per added signal, otherwise they override the previous signal. +
     Some signals can be specified to trigger based on the application name and/or window title, and its active/focused state.
 
 *--remove '<SIGNAL_SEL>'*::


### PR DESCRIPTION
While writing my Yabai Wrapper, I noticed that when adding multiple signals with the same label, they override themselves.
Because I didn't expect this behavior, I think it is better to document it is a feature. 