### PR TITLE
Update yabai.asciidoc with sections for rule arguments

### DIFF
--- a/doc/yabai.asciidoc
+++ b/doc/yabai.asciidoc
@@ -633,6 +633,8 @@ ARGUMENT
 *label='<LABEL>'*::
     Label used to identify the rule with a unique name
 
+Filter properties to match:
+
 *app[!]='<REGEX>'*::
     Name of application. If '!' is present, invert the match.
 
@@ -644,6 +646,8 @@ ARGUMENT
 
 *subrole[!]='<REGEX>'*::
     https://developer.apple.com/documentation/applicationservices/carbon_accessibility/subroles?language=objc[Accessibility subrole of window]. If '!' is present, invert the match.
+
+Window properties to set:
 
 *display='[^]<DISPLAY_SEL>'*::
     Send window to display. If '^' is present, follow focus.


### PR DESCRIPTION
Currently it's a bit hard to understand when reading the documentation if arguments to `yabai -m rule` are values to match or values to set.

Hopefully this clarifies it.