### PR TITLE
docs: fix broken whitespaces between badges in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,15 @@
 </p>
 <p align="center">
   <a href="https://github.com/koekeishiya/yabai/blob/master/LICENSE.txt">
-    <img src="https://img.shields.io/github/license/koekeishiya/yabai.svg?color=green" alt="License Badge">
-  </a>
+    <img src="https://img.shields.io/github/license/koekeishiya/yabai.svg?color=green" alt="License Badge"></a>
   <a href="https://github.com/koekeishiya/yabai/blob/master/doc/yabai.asciidoc">
-    <img src="https://img.shields.io/badge/view-documentation-green.svg" alt="Documentation Badge">
-  </a>
+    <img src="https://img.shields.io/badge/view-documentation-green.svg" alt="Documentation Badge"></a>
   <a href="https://github.com/koekeishiya/yabai/wiki">
-    <img src="https://img.shields.io/badge/view-wiki-green.svg" alt="Wiki Badge">
-  </a>
+    <img src="https://img.shields.io/badge/view-wiki-green.svg" alt="Wiki Badge"></a>
   <a href="https://github.com/koekeishiya/yabai/blob/master/CHANGELOG.md">
-    <img src="https://img.shields.io/badge/view-changelog-green.svg" alt="Changelog Badge">
-  </a>
+    <img src="https://img.shields.io/badge/view-changelog-green.svg" alt="Changelog Badge"></a>
   <a href="https://github.com/koekeishiya/yabai/releases">
-    <img src="https://img.shields.io/github/commits-since/koekeishiya/yabai/latest.svg?color=green" alt="Version Badge">
-  </a>
+    <img src="https://img.shields.io/github/commits-since/koekeishiya/yabai/latest.svg?color=green" alt="Version Badge"></a>
 </p>
 
 ## About


### PR DESCRIPTION
Removes underlines from whitespaces between badges in the `README.md` file of this repository.

_See also:_ https://github.com/orgs/community/discussions/154640