### PR TITLE
Append commit hash to `--version` output when building from HEAD

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,6 +14,12 @@ OSAX_PATH      = ./src/osax
 INFO_PLIST     = $(ASSET_PATH)/Info.plist
 BINS           = $(BUILD_PATH)/yabai
 
+# Embed the current git commit hash (short) if available
+GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "")
+ifneq ($(GIT_HASH),)
+CLI_FLAGS += -DGIT_COMMIT_HASH=\"$(GIT_HASH)\"
+endif
+
 .PHONY: all asan tsan install man icon archive publish sign clean-build clean
 
 all: clean-build $(BINS)

--- a/src/yabai.c
+++ b/src/yabai.c
@@ -202,7 +202,11 @@ static void parse_arguments(int argc, char **argv)
 
     if ((string_equals(argv[1], VERSION_OPT_LONG)) ||
         (string_equals(argv[1], VERSION_OPT_SHRT))) {
+#ifdef GIT_COMMIT_HASH
+        fprintf(stdout, "yabai-v%d.%d.%d-%s\n", MAJOR, MINOR, PATCH, GIT_COMMIT_HASH);
+#else
         fprintf(stdout, "yabai-v%d.%d.%d\n", MAJOR, MINOR, PATCH);
+#endif
         exit(EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
With the recent macOS Tahoe upgrade, there is an increase in issues as we uncover problems we need to work around (e.g., #2638)

Users can report “I'm running 7.1.15” — but that doesn’t distinguish between official releases and custom HEAD builds.

Appending the commit hash makes it immediately clear exactly what code a user is running, especially as incremental patches are added over the coming weeks.  Since the adding of the commit is optional, it doesn't need to be included for release builds.

Future improvements could include appending a -dirty suffix if the working tree has uncommitted changes, but that’s left out here for simplicity.

I just built from HEAD, and get:

```sh
$  ./bin/yabai --version
yabai-v7.1.15-46ef675
```