### PR TITLE
Fix: Auto focus stops working after some time

### DIFF
--- a/src/window_manager.c
+++ b/src/window_manager.c
@@ -1293,12 +1293,12 @@ void window_manager_focus_window_without_raise(ProcessSerialNumber *window_psn, 
 
         //
         // @hack
-        // Artificially delay the activation by 1ms. This is necessary
+        // Artificially delay the activation by 40ms. This is necessary
         // because some applications appear to be confused if both of
         // the events appear instantaneously.
         //
 
-        usleep(10000);
+        usleep(40000);
 
         g_event_bytes[0x8a] = 0x01;
         memcpy(g_event_bytes + 0x3c, &window_id, sizeof(uint32_t));


### PR DESCRIPTION
I am not experienced in this kind of development, just wanted to share my fix for auto focus breaking since other people seem to have the same issue  (https://github.com/koekeishiya/yabai/issues/2217). No hard feelings if this is not merged in!

When hovering over different windows auto focus seems to break and stops working until a manual focus is triggered via a mouse click. Cause is g_mouse_state.ffm_window_id never being set back to 0, since the focus event is never being sent from the os.

Increasing the delay in this hack to 40ms solves the breaking of autofocus on my machine (macbook air m4 macos 26).