### PR TITLE
fix(focus_follows_mouse): don't reset g_window_manager.ffm_mode when it is called without a corresponding MENU_OPENED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Update scripting addition for macOS 26.2 Apple Silicon [#2693](https://github.com/asmvik/yabai/issues/2693)
 - Fix window sub-level query for macOS 26 [#2726](https://github.com/asmvik/yabai/issues/2726)
+- Fix focus_follows_mouse where MENU_CLOSED was resetting ffm_mode when called without a corresponding MENU_OPENED [#2740](https://github.com/asmvik/yabai/pull/2740)
 
 ## [7.1.16] - 2025-10-07
 ### Changed

--- a/src/event_loop.c
+++ b/src/event_loop.c
@@ -1535,10 +1535,10 @@ static EVENT_HANDLER(MENU_CLOSED)
     --is_menu_open;
 
     if (is_menu_open < 0) {
+        // Sometimes Chrome apps call MENU_CLOSED without a corresponding MENU_OPENED,
+        // so just reset the `is_menu_open` and don't reset the FFM mode.
         is_menu_open = 0;
-    }
-
-    if (is_menu_open == 0) {
+    } else if (is_menu_open == 0) {
         g_window_manager.ffm_mode = ffm_value;
     }
 }


### PR DESCRIPTION
i observed these logs when running `yabai --verbose`:
```
EVENT_HANDLER_WINDOW_TITLE_CHANGED: Terminal 46053
EVENT_HANDLER_APPLICATION_LAUNCHED: Google Calendar (42983) is not finished launching, subscribing to finishedLaunching changes
EVENT_HANDLER_WINDOW_TITLE_CHANGED: Terminal 46053
-[workspace_context observeValueForKeyPath:ofObject:change:context:]: Google Calendar (42983) finished launching
EVENT_HANDLER_APPLICATION_LAUNCHED: Google Calendar (42983)
EVENT_HANDLER_APPLICATION_FRONT_SWITCHED: Google Calendar (42983)
window_manager_create_and_add_window:46295 Google Calendar -  (AXWindow:AXStandardWindow:1)
EVENT_HANDLER_WINDOW_TITLE_CHANGED: Google Calendar 46295
EVENT_HANDLER_WINDOW_FOCUSED: Google Calendar 46295
EVENT_HANDLER_WINDOW_RESIZED: Google Calendar 46295
EVENT_HANDLER_WINDOW_MOVED:DEBOUNCED Google Calendar 46295
EVENT_HANDLER_WINDOW_TITLE_CHANGED: Google Calendar 46295
EVENT_HANDLER_MENU_CLOSED
EVENT_HANDLER_MENU_CLOSED
```

so i think MENU_CLOSED is being called without MENU_OPENED, which leaves `ffm_value` enum default to FFM_DISABLED.

- This patch just avoids setting `g_window_manager.ffm_mode` if `is_menu_open` was negative because that means it was probably called without a corresponding MENU_OPENED.

- (Alternatively, another fix could be saving `ffm_value = g_window_manager.ffm_mode` earlier than just in `EVENT_HANDLER(MENU_OPENED)`)

fixes #2217